### PR TITLE
Fix quick-start workflow SVG on pkgdown

### DIFF
--- a/vignettes/quick-start-vignette.Rmd
+++ b/vignettes/quick-start-vignette.Rmd
@@ -141,7 +141,11 @@ The accepted shift set defines the optimal no-uncertainty configuration under th
 The figure below summarizes the main stages of the greedy search and post-processing workflow implemented in `bifrost`.
 
 ```{r workflow_diagram, echo=FALSE, eval=TRUE, results='asis'}
-cat('<p align="center"><img src="quick-start/bifrost-workflow.svg" alt="Workflow diagram showing setup, baseline scoring, greedy search, post-processing, and output steps in bifrost." style="max-width:100%; height:auto;" /></p>')
+svg_uri <- knitr::image_uri("quick-start/bifrost-workflow.svg")
+cat(sprintf(
+  '<p align="center"><img src="%s" alt="Workflow diagram showing setup, baseline scoring, greedy search, post-processing, and output steps in bifrost." style="max-width:100%%; height:auto;" /></p>',
+  svg_uri
+))
 ```
 
 Because the search is greedy, it can converge to a local optimum. In practice, it is useful to repeat analyses with different `min_descendant_tips`, thresholds, and IC choices to assess robustness.


### PR DESCRIPTION
## Summary
- fix the quick-start workflow figure so pkgdown embeds the SVG instead of linking to a missing asset
- keep the source asset as SVG
- preserve the existing workflow section text and lead-in

## Validation
- built articles locally with `pkgdown::build_articles()`
- confirmed the previous missing-image warning disappeared
- confirmed `docs/articles/quick-start-vignette.html` now contains an embedded `data:image/svg+xml` workflow image