### PR TITLE
[codex] Update package citation metadata

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -21,7 +21,7 @@ bibentry(
 
 ## 2. bifrost methods / package preprint
 bibentry(
-  bibtype = "Unpublished",
+  bibtype = "Article",
   title   = "bifrost: an R package for scalable inference of phylogenetic shifts in multivariate evolutionary dynamics",
   author  = c(
     person(c("Jacob",  "S."), "Berv"),
@@ -36,7 +36,10 @@ bibentry(
     person(c("Brian","C."),   "Weeks")
   ),
   year    = "2026",
-  note    = "Preprint describing the bifrost R package."
+  journal = "bioRxiv",
+  doi     = "10.64898/2026.04.12.718036",
+  url     = "https://doi.org/10.64898/2026.04.12.718036",
+  note    = "Preprint, version 1."
 )
 
 ## 3. Software / package manual citation

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,4 +1,10 @@
-citHeader("To cite bifrost in publications, please use the following references, as appropriate:")
+citHeader(
+  paste(
+    "To cite bifrost in publications, please use the following references, as appropriate.",
+    "Because bifrost relies on mvMORPH and its penalized-likelihood framework,",
+    "please also cite the mvMORPH references below."
+  )
+)
 
 ## 1. Methods / application manuscript (in press)
 bibentry(
@@ -61,4 +67,40 @@ bibentry(
   year    = "2026",
   note    = "R package version 0.1.3",
   url     = "https://CRAN.R-project.org/package=bifrost"
+)
+
+## 4. mvMORPH package citation
+bibentry(
+  bibtype = "Article",
+  title   = "mvmorph: an r package for fitting multivariate evolutionary models to morphometric data",
+  author  = c(
+    person("Julien",  "Clavel"),
+    person("Gilles",  "Escarguel"),
+    person("Gildas",  "Merceron")
+  ),
+  year    = "2015",
+  journal = "Methods in Ecology and Evolution",
+  volume  = "6",
+  number  = "11",
+  pages   = "1311-1319",
+  doi     = "10.1111/2041-210X.12420",
+  url     = "https://doi.org/10.1111/2041-210X.12420"
+)
+
+## 5. Penalized-likelihood framework citation
+bibentry(
+  bibtype = "Article",
+  title   = "A Penalized Likelihood Framework for High-Dimensional Phylogenetic Comparative Methods and an Application to New-World Monkeys Brain Evolution",
+  author  = c(
+    person("Julien",   "Clavel"),
+    person("Leandro",  "Aristide"),
+    person("Hélène",   "Morlon")
+  ),
+  year    = "2019",
+  journal = "Systematic Biology",
+  volume  = "68",
+  number  = "1",
+  pages   = "93-116",
+  doi     = "10.1093/sysbio/syy045",
+  url     = "https://doi.org/10.1093/sysbio/syy045"
 )


### PR DESCRIPTION
## Summary
- update the bifrost preprint entry in `inst/CITATION` to use the live bioRxiv metadata and DOI
- add the 2015 `mvMORPH` package paper and the 2019 penalized-likelihood framework paper to `citation("bifrost")`
- clarify in the citation header that the mvMORPH references should also be cited because they are core underlying machinery

## Why
The bifrost preprint is now live, so the package citation metadata can point to the actual bioRxiv record instead of a generic preprint note. Adding the mvMORPH references makes the package citation output better reflect the core external methods and software the package depends on.

## Validation
- ran `Rscript` sanity checks to confirm `inst/CITATION` still parses after both updates