### PR TITLE
[codex] Add dynamic bioRxiv badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Codecov test coverage](https://codecov.io/gh/jakeberv/bifrost/graph/badge.svg)](https://app.codecov.io/gh/jakeberv/bifrost)
 [![CRAN status](https://www.r-pkg.org/badges/version/bifrost)](https://CRAN.R-project.org/package=bifrost)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/bifrost)](https://cran.r-project.org/package=bifrost)
+[![bioRxiv preprint](https://img.shields.io/endpoint?url=https%3A%2F%2Fjakeberv.github.io%2Fbiorxiv-badge%2Fbadges%2F10.64898__2026.04.12.718036.json)](https://doi.org/10.64898/2026.04.12.718036)
 [![License: GPL (>= 2)](https://img.shields.io/badge/license-GPL%20(%E2%89%A5%202)-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
 <!-- badges: end -->


### PR DESCRIPTION
## Summary
- add a dynamic bioRxiv badge to the README badge row
- link the badge to the live bifrost preprint DOI

## Why
The bifrost preprint is now live, and the dynamic badge will automatically update if the preprint later gets published in a journal.

## Validation
- verified the generated badge endpoint returns the expected `bioRxiv: preprint` status
- confirmed the README change is limited to the badge block