### PR TITLE
[codex] Polish citation metadata and README block

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,28 @@ Though `bifrost` was initially developed as a framework for inferring macroevolu
 
 ## Citation
 
-If you use `bifrost`, please cite the references returned by:
+If you use `bifrost`, please cite the package and methods references below. The same set is also available from:
 
 ```r
 citation("bifrost")
 ```
+
+### Recommended citations
+
+1. `bifrost` methods / application paper  
+   Berv JS, Probst CM, Claramunt S, Shipley JR, Friedman M, Smith SA, Fouhey DF, Weeks BC (2026). *Rates of passerine body plan evolution in time and space*. *Nature Ecology & Evolution*. In press.
+
+2. `bifrost` preprint  
+   Berv JS, Fox N, Thorstensen MJ, Lloyd-Laney H, Troyer EM, Rivero-Vega RA, Smith SA, Friedman M, Fouhey DF, Weeks BC (2026). *bifrost: an R package for scalable inference of phylogenetic shifts in multivariate evolutionary dynamics*. *bioRxiv*. [https://doi.org/10.64898/2026.04.12.718036](https://doi.org/10.64898/2026.04.12.718036)
+
+3. `bifrost` software citation  
+   Berv JS, Fox N, Thorstensen MJ, Lloyd-Laney H, Troyer EM, Rivero-Vega RA, Smith SA, Friedman M, Fouhey DF, Weeks BC (2026). *Branch-Level Inference Framework for Recognizing Optimal Shifts in Traits*. R package version 0.1.3. [https://CRAN.R-project.org/package=bifrost](https://CRAN.R-project.org/package=bifrost)
+
+4. `mvMORPH` package paper  
+   Clavel J, Escarguel G, Merceron G (2015). *mvmorph: an R package for fitting multivariate evolutionary models to morphometric data*. *Methods in Ecology and Evolution*, 6(11), 1311-1319. [https://doi.org/10.1111/2041-210X.12420](https://doi.org/10.1111/2041-210X.12420)
+
+5. Penalized-likelihood framework paper  
+   Clavel J, Aristide L, Morlon H (2019). *A Penalized Likelihood Framework for High-Dimensional Phylogenetic Comparative Methods and an Application to New-World Monkeys Brain Evolution*. *Systematic Biology*, 68(1), 93-116. [https://doi.org/10.1093/sysbio/syy045](https://doi.org/10.1093/sysbio/syy045)
 
 ## Contributing
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -44,8 +44,7 @@ bibentry(
   year    = "2026",
   journal = "bioRxiv",
   doi     = "10.64898/2026.04.12.718036",
-  url     = "https://doi.org/10.64898/2026.04.12.718036",
-  note    = "Preprint, version 1."
+  note    = "Preprint version 1."
 )
 
 ## 3. Software / package manual citation
@@ -72,7 +71,7 @@ bibentry(
 ## 4. mvMORPH package citation
 bibentry(
   bibtype = "Article",
-  title   = "mvmorph: an r package for fitting multivariate evolutionary models to morphometric data",
+  title   = "mvmorph: an R package for fitting multivariate evolutionary models to morphometric data",
   author  = c(
     person("Julien",  "Clavel"),
     person("Gilles",  "Escarguel"),
@@ -83,8 +82,7 @@ bibentry(
   volume  = "6",
   number  = "11",
   pages   = "1311-1319",
-  doi     = "10.1111/2041-210X.12420",
-  url     = "https://doi.org/10.1111/2041-210X.12420"
+  doi     = "10.1111/2041-210X.12420"
 )
 
 ## 5. Penalized-likelihood framework citation
@@ -101,6 +99,5 @@ bibentry(
   volume  = "68",
   number  = "1",
   pages   = "93-116",
-  doi     = "10.1093/sysbio/syy045",
-  url     = "https://doi.org/10.1093/sysbio/syy045"
+  doi     = "10.1093/sysbio/syy045"
 )


### PR DESCRIPTION
## Summary
- add a formatted citation block to the README citation section
- clean up `inst/CITATION` output by removing redundant DOI URLs from article entries
- simplify the preprint note text and capitalize `R` in the `mvmorph` package-paper title

## Why
This makes the README citation guidance easier to copy and improves the formatting of `citation("bifrost")` in base R without changing the underlying citation intent.

## Validation
- reran the citation-file parse/render sanity check via `utils::readCitationFile()`
- inspected the rendered `citation("bifrost")` output after the cleanup