### PR TITLE
Make CRAN downloads updater open a PR

### DIFF
--- a/.github/workflows/update-cran-downloads.yml
+++ b/.github/workflows/update-cran-downloads.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: write
-  actions: write
+  pull-requests: write
 
 concurrency:
   group: cran-downloads-chart
@@ -45,9 +45,12 @@ jobs:
         working-directory: tools/cran-downloads
         run: pnpm run update
 
-      - name: Commit updated CRAN downloads artifacts
-        id: commit
+      - name: Open update pull request
+        id: update-pr
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           paths=(
             tools/cran-downloads/data/bifrost-cran-downloads.json
@@ -61,17 +64,24 @@ jobs:
             exit 0
           fi
 
+          branch="automation/cran-downloads-update"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
 
           git add "${paths[@]}"
           git commit -m "Update CRAN downloads data and chart"
-          git push
+          git push --force-with-lease origin "$branch"
+
+          if gh pr view "$branch" --json url --jq .url >/tmp/cran-downloads-pr-url 2>/dev/null; then
+            echo "Updated existing PR: $(cat /tmp/cran-downloads-pr-url)"
+          else
+            gh pr create \
+              --base "$BASE_BRANCH" \
+              --head "$branch" \
+              --title "Update CRAN downloads data and chart" \
+              --body "Automated weekly update of stored CRAN downloads data and the generated chart artifacts."
+          fi
 
           echo "changed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Trigger pkgdown rebuild
-        if: steps.commit.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run pkgdown.yml --ref "${{ github.ref_name }}"

--- a/man/generateViridisColorScale.Rd
+++ b/man/generateViridisColorScale.Rd
@@ -49,5 +49,5 @@ if (requireNamespace("viridis", quietly = TRUE)) {
 
 }
 \seealso{
-\code{\link[viridis:reexports]{viridis::viridis()}} for details on the color palette.
+\code{\link[viridis:viridis]{viridis::viridis()}} for details on the color palette.
 }

--- a/tools/cran-downloads/README.md
+++ b/tools/cran-downloads/README.md
@@ -34,13 +34,13 @@ Use the PNG in Markdown. The SVG is retained as a render source, but PNG output 
 
 ## Automation
 
-`.github/workflows/update-cran-downloads.yml` updates the stored JSON and chart once per week. If the JSON or chart changes, the workflow commits:
+`.github/workflows/update-cran-downloads.yml` updates the stored JSON and chart once per week. If the JSON or chart changes, the workflow opens or updates an automated pull request with:
 
 - `data/bifrost-cran-downloads.json`
 - `output/cran-downloads.svg`
 - `output/cran-downloads.png`
 
-The workflow then dispatches the pkgdown workflow so the site can pick up the new PNG.
+The workflow uses a pull request instead of pushing directly to `main`, so it works with branch protection rules.
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

- Fixes the CRAN downloads updater for protected `main`.
- Opens or updates an automated PR when regenerated CRAN data/chart artifacts change.
- Removes the direct push to `main`, which branch protection rejects.

## Validation

- Parsed the workflow YAML successfully.
- Confirmed the prior manual workflow run completed chart generation and failed only on protected-branch push.
