### PR TITLE
Use persistent CRAN downloads update branch

### DIFF
--- a/.github/workflows/update-cran-downloads.yml
+++ b/.github/workflows/update-cran-downloads.yml
@@ -17,10 +17,20 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    env:
+      BASE_BRANCH: ${{ github.event.repository.default_branch }}
+      UPDATE_BRANCH: automation/cran-downloads
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Prepare persistent update branch
+        shell: bash
+        run: |
+          git fetch origin "refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"
+          git fetch origin "refs/heads/${UPDATE_BRANCH}:refs/remotes/origin/${UPDATE_BRANCH}" || true
+          git checkout -B "$UPDATE_BRANCH" "origin/$BASE_BRANCH"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -50,7 +60,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           paths=(
             tools/cran-downloads/data/bifrost-cran-downloads.json
@@ -64,22 +73,23 @@ jobs:
             exit 0
           fi
 
-          branch="automation/cran-downloads-update"
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$branch"
 
           git add "${paths[@]}"
           git commit -m "Update CRAN downloads data and chart"
-          git push --force-with-lease origin "$branch"
+          if git show-ref --verify --quiet "refs/remotes/origin/$UPDATE_BRANCH"; then
+            git push --force-with-lease origin "$UPDATE_BRANCH:$UPDATE_BRANCH"
+          else
+            git push origin "$UPDATE_BRANCH:$UPDATE_BRANCH"
+          fi
 
-          if gh pr view "$branch" --json url --jq .url >/tmp/cran-downloads-pr-url 2>/dev/null; then
+          if gh pr view "$UPDATE_BRANCH" --json url --jq .url >/tmp/cran-downloads-pr-url 2>/dev/null; then
             echo "Updated existing PR: $(cat /tmp/cran-downloads-pr-url)"
           else
             gh pr create \
               --base "$BASE_BRANCH" \
-              --head "$branch" \
+              --head "$UPDATE_BRANCH" \
               --title "Update CRAN downloads data and chart" \
               --body "Automated weekly update of stored CRAN downloads data and the generated chart artifacts."
           fi

--- a/tools/cran-downloads/README.md
+++ b/tools/cran-downloads/README.md
@@ -34,13 +34,15 @@ Use the PNG in Markdown. The SVG is retained as a render source, but PNG output 
 
 ## Automation
 
-`.github/workflows/update-cran-downloads.yml` updates the stored JSON and chart once per week. If the JSON or chart changes, the workflow opens or updates an automated pull request with:
+`.github/workflows/update-cran-downloads.yml` updates the stored JSON and chart once per week.
+
+Each run rebuilds the persistent `automation/cran-downloads` branch from the current default branch, regenerates the data and chart, and force-updates that branch only when the generated artifacts differ. This keeps a single standing automated pull request with:
 
 - `data/bifrost-cran-downloads.json`
 - `output/cran-downloads.svg`
 - `output/cran-downloads.png`
 
-The workflow uses a pull request instead of pushing directly to `main`, so it works with branch protection rules.
+The workflow uses a pull request instead of pushing directly to `main`, so it works with branch protection rules. Merging the PR makes the stored JSON on `main` the canonical archive for the next run.
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

- switch the CRAN downloads updater to a persistent `automation/cran-downloads` branch
- rebuild that branch from the current default branch before regenerating artifacts
- keep one standing automated PR instead of creating dated/new update branches
- document the persistent-branch behavior in the tracker README

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update-cran-downloads.yml"); puts "workflow yaml ok"'`
