### PR TITLE
[codex] Document rateMap phytools provenance

### DIFF
--- a/R/rate-map.R
+++ b/R/rate-map.R
@@ -675,6 +675,16 @@
 #' with equal weight.
 #'
 #' @details
+#' **Algorithmic provenance.** `rateMap()` is inspired by
+#' [phytools::densityMap()], which summarizes a set of stochastic maps by
+#' slicing mapped branches on a shared depth grid and coloring a SIMMAP-style
+#' tree by an averaged branchwise quantity. Here the averaged quantity is not a
+#' posterior probability of a mapped state; instead, each mapped state is
+#' translated through the corresponding fitted regime-rate parameter from each
+#' run. The plotting interface likewise follows the `phytools` density-map
+#' family by returning a colored SIMMAP tree and drawing it with
+#' [phytools::plotSimmap()] plus a continuous color-bar legend.
+#'
 #' `rateMap()` can also summarize same-topology posterior or sensitivity samples
 #' where branch lengths differ. In that case, supply `check = "topology"` and,
 #' usually, an explicit `target_tree`. This can be any target or summary tree
@@ -855,7 +865,8 @@
 #'   \item{`omitted`}{Integer indices of omitted fits when `na_action = "omit"`.}
 #' }
 #'
-#' @seealso [plotRateMap()], [phytools::plotSimmap()]
+#' @seealso [plotRateMap()], [phytools::densityMap()],
+#'   [phytools::plotSimmap()]
 #'
 #' @examples
 #' \dontrun{
@@ -1371,6 +1382,8 @@ rateMap <- function(
 #'
 #' Render a rate-variation map produced by [rateMap()] using
 #' [phytools::plotSimmap()] and a continuous color-bar legend.
+#' The plotting controls intentionally mirror the `phytools` density-map
+#' plotting style for phylogram, fan, and arc layouts.
 #'
 #' @param x An object of class `"rateMap"` returned by [rateMap()].
 #' @param value Character interval column to map to branch colors. The default
@@ -1388,7 +1401,7 @@ rateMap <- function(
 #'
 #' @return Invisibly returns `x`.
 #'
-#' @seealso [rateMap()]
+#' @seealso [rateMap()], [phytools::densityMap()], [phytools::plotSimmap()]
 #'
 #' @examples
 #' \dontrun{

--- a/man/plotRateMap.Rd
+++ b/man/plotRateMap.Rd
@@ -34,6 +34,8 @@ Invisibly returns \code{x}.
 \description{
 Render a rate-variation map produced by \code{\link[=rateMap]{rateMap()}} using
 \code{\link[phytools:plotSimmap]{phytools::plotSimmap()}} and a continuous color-bar legend.
+The plotting controls intentionally mirror the \code{phytools} density-map
+plotting style for phylogram, fan, and arc layouts.
 }
 \examples{
 \dontrun{
@@ -51,5 +53,5 @@ plotRateMap(rm_obj, value = "sd", palette = "Inferno")
 
 }
 \seealso{
-\code{\link[=rateMap]{rateMap()}}
+\code{\link[=rateMap]{rateMap()}}, \code{\link[phytools:densityMap]{phytools::densityMap()}}, \code{\link[phytools:plotSimmap]{phytools::plotSimmap()}}
 }

--- a/man/rateMap.Rd
+++ b/man/rateMap.Rd
@@ -223,6 +223,16 @@ lengths, branches are sliced on a global depth grid, and runs are averaged
 with equal weight.
 }
 \details{
+\strong{Algorithmic provenance.} \code{rateMap()} is inspired by
+\code{\link[phytools:densityMap]{phytools::densityMap()}}, which summarizes a set of stochastic maps by
+slicing mapped branches on a shared depth grid and coloring a SIMMAP-style
+tree by an averaged branchwise quantity. Here the averaged quantity is not a
+posterior probability of a mapped state; instead, each mapped state is
+translated through the corresponding fitted regime-rate parameter from each
+run. The plotting interface likewise follows the \code{phytools} density-map
+family by returning a colored SIMMAP tree and drawing it with
+\code{\link[phytools:plotSimmap]{phytools::plotSimmap()}} plus a continuous color-bar legend.
+
 \code{rateMap()} can also summarize same-topology posterior or sensitivity samples
 where branch lengths differ. In that case, supply \code{check = "topology"} and,
 usually, an explicit \code{target_tree}. This can be any target or summary tree
@@ -340,5 +350,6 @@ plotRateMap(rm_sub, type = "arc", show_tip_labels = FALSE, lwd = 1)
 
 }
 \seealso{
-\code{\link[=plotRateMap]{plotRateMap()}}, \code{\link[phytools:plotSimmap]{phytools::plotSimmap()}}
+\code{\link[=plotRateMap]{plotRateMap()}}, \code{\link[phytools:densityMap]{phytools::densityMap()}},
+\code{\link[phytools:plotSimmap]{phytools::plotSimmap()}}
 }


### PR DESCRIPTION
## Summary

- Document that `rateMap()` is algorithmically inspired by `phytools::densityMap()`.
- Clarify that `rateMap()` adapts the density-map branch-slicing and SIMMAP-coloring idea to fitted regime-rate summaries.
- Add `phytools::densityMap()` to the relevant seealso links for `rateMap()` and `plotRateMap()`.

## Validation

- `tools::checkRd("man/rateMap.Rd")`
- `tools::checkRd("man/plotRateMap.Rd")`
- `git diff --check`