### PR TITLE
[codex] Document development feature status

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ Install [Rtools](https://cran.r-project.org/bin/windows/Rtools/) for your R vers
 **macOS users:**  
 You may need to install [XQuartz](https://www.xquartz.org/) to build or run packages that depend on certain graphical or system libraries.
 
+## Release status
+
+CRAN currently provides `bifrost` 0.1.4. The GitHub development version includes features that are documented here but not yet available from CRAN.
+
+- **New since CRAN 0.1.4.** The `rateMap()` workflow, along with `rateMapView()`, `rateMapControl()`, `rateMapRateFlags()`, and `plot()` / `print()` methods for `rateMap` objects, summarizes and visualizes branch-rate patterns from completed `bifrost` searches. The two rate-map jaw-shape articles below are part of this development-version documentation.
+- **Experimental or repository-only material.** Some workflows described in the repository are still being actively developed, especially pGLS-style uses of `bifrost` for predictor models with hidden branch-specific rate variation. Repository tooling and generated site assets, such as the CRAN downloads tracker, support development and documentation rather than the core CRAN API.
+
 ## Overview
 
 - **Primary goal.** Infer *where*, *when*, and *how* patterns of phenotypic evolution change across a tree using many traits simultaneously.


### PR DESCRIPTION
## Summary

Adds a short README release-status section that distinguishes GitHub-only development features from the current CRAN release.

## Details

- Notes that CRAN currently provides `bifrost` 0.1.4.
- Calls out the new `rateMap()` workflow and related helpers as development-version features not yet on CRAN.
- Separates experimental or repository-only material, including active pGLS-style hidden-rate workflows and development documentation tooling.

## Validation

- Rendered the README locally and reviewed the new section in the browser.
- README-only change; no package tests run.