### PR TITLE
[codex] Fix CRAN downloads PR detection

### DIFF
--- a/.github/workflows/update-cran-downloads.yml
+++ b/.github/workflows/update-cran-downloads.yml
@@ -85,8 +85,15 @@ jobs:
             git push origin "$UPDATE_BRANCH:$UPDATE_BRANCH"
           fi
 
-          if gh pr view "$UPDATE_BRANCH" --json url --jq .url >/tmp/cran-downloads-pr-url 2>/dev/null; then
-            echo "Updated existing PR: $(cat /tmp/cran-downloads-pr-url)"
+          open_pr_url="$(gh pr list \
+            --base "$BASE_BRANCH" \
+            --head "$UPDATE_BRANCH" \
+            --state open \
+            --json url \
+            --jq '.[0].url')"
+
+          if [ -n "$open_pr_url" ]; then
+            echo "Updated existing PR: $open_pr_url"
           else
             gh pr create \
               --base "$BASE_BRANCH" \


### PR DESCRIPTION
## Summary

Fix the CRAN downloads workflow so it only treats an existing **open** PR from `automation/cran-downloads` to `main` as reusable.

## Why

The previous `gh pr view "$UPDATE_BRANCH"` check can resolve an old merged PR from the same head branch, which caused the June 1 scheduled run to skip creating a new PR after force-pushing fresh CRAN artifacts.

## Validation

- `git diff --check -- .github/workflows/update-cran-downloads.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update-cran-downloads.yml"); puts "YAML ok"'`