### PR TITLE
Document main-only IC trajectory changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ You may need to install [XQuartz](https://www.xquartz.org/) to build or run pack
 
 CRAN currently provides `bifrost` 0.1.4. The GitHub development version includes repository-only additions documented here but not yet available from CRAN:
 
+- Search histories can now be inspected with the `icTrajectory()` extractor and plotted directly with `plot()`, for example `traj <- icTrajectory(search); plot(traj)`. The older `plot_ic_acceptance_matrix()` helper remains available as a compatibility wrapper.
+- Stored model-fit histories now include richer per-candidate records, including errored candidate fits, so search diagnostics can preserve accepted, rejected, and errored proposals.
 - The `rateMap()` workflow, along with `rateMapView()`, `rateMapControl()`, `rateMapRateFlags()`, and `plot()` / `print()` methods for `rateMap` objects, summarizes and visualizes branch-rate patterns from completed `bifrost` searches. The two rate-map jaw-shape articles below are part of this development-version documentation.
 - Formula-based searches now accept formula objects as well as character strings, support numeric response-only data frames for intercept-only searches, and support named-column data-frame formulas such as `cbind(y1, y2) ~ size + grp` for pGLS-style workflows.
 


### PR DESCRIPTION
## Summary

- update the README release-status section to call out main-only IC trajectory changes relative to CRAN 0.1.4
- mention the new `icTrajectory(search); plot(traj)` workflow and the `plot_ic_acceptance_matrix()` compatibility wrapper
- mention richer stored model-fit histories, including errored candidate fits

## Validation

- `git diff --check`
