### PR TITLE
[codex] Improve jaw shape vignette organization

### DIFF
--- a/vignettes/jaw-shape-vignette.Rmd
+++ b/vignettes/jaw-shape-vignette.Rmd
@@ -60,8 +60,7 @@ if (identical(Sys.getenv("IN_PKGDOWN"), "true")) {
 ```
 
 We will walk through an example using a fossil dataset from [Troyer et al. (2025)](https://doi.org/10.1016/j.cub.2025.08.008), which examines macroevolutionary patterns of jaw shape in the earliest radiation of bony fishes. *`bifrost`* assumes that the branch lengths of the input phylogeny are in units of time, and does not require ultrametric phylogenies.
-<br>
-<br>
+
 ```{r troyer_fig1, echo=FALSE, fig.align="center", out.width="60%", fig.alt="Figure from Troyer et al. (2025) showing contrasting jaw-shape space exploration among early bony fishes."}
 knitr::include_graphics("jaw-shape/gr1_lrg_png24.png")
 ```
@@ -133,19 +132,17 @@ str(fish.data)
 
 The core of the *`bifrost`* workflow is the `searchOptimalConfiguration()` function. This function automates the process of identifying the optimal placement of evolutionary regime shifts on the tree.
 
-### The Function Call
+### Optional Runtime Setup
 
-Here is the function call we will use for this analysis. We'll break down each parameter choice below.
+The next chunk is optional. It tweaks runtime behavior only: memory limits, live plotting, and the session-level BLAS/OpenMP thread cap used by sequential linear algebra. None of these choices changes the model or search logic.
 
-  * Optional: tweaks runtime/performance/plotting behavior (memory limit, interactive plotting device, BLAS/OpenMP thread env vars) and doesn’t change the model/search logic itself—so you can omit it if your defaults are fine or you’re running non-interactively / on a managed environment.
-
-```{r run_bifrost_setup, eval=FALSE, message = TRUE}
+```{r runtime_setup, eval=FALSE, message = TRUE}
 # ---- Optional: increase future globals limit (needed for large objects) ----
 options(future.globals.maxSize = 10 * 1024^3)
 
-# ---- Optional: open a dedicated plotting device when running interactively ----
-# (You can skip this entirely if plot = FALSE)
-if (interactive()) {
+# ---- Optional: open a dedicated plotting device for live search plots ----
+use_live_plot <- FALSE
+if (interactive() && use_live_plot) {
   if (.Platform$OS.type == "windows") {
     windows()
   } else if (Sys.info()[["sysname"]] == "Darwin") {
@@ -156,10 +153,12 @@ if (interactive()) {
 }
 
 # ---- Optional: speed up SEQUENTIAL linear algebra via BLAS/OpenMP threads ----
-# NOTE: bifrost caps BLAS/OpenMP threads to 1 *inside* its PARALLEL blocks to 
+# NOTE: bifrost caps BLAS/OpenMP threads to 1 inside its PARALLEL blocks to
 # avoid oversubscription.
-{thread_vars <- c("OMP_NUM_THREADS","OPENBLAS_NUM_THREADS","MKL_NUM_THREADS",
-                  "VECLIB_MAXIMUM_THREADS")
+thread_vars <- c(
+  "OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+  "VECLIB_MAXIMUM_THREADS"
+)
 old_threads <- Sys.getenv(thread_vars, unset = NA_character_)
 
 n_threads <- "4"  # must be a character string
@@ -169,6 +168,15 @@ Sys.setenv(
   MKL_NUM_THREADS        = n_threads,
   VECLIB_MAXIMUM_THREADS = n_threads
 )
+```
+
+### The Function Call
+
+Here is the function call we will use for this analysis. We'll break down each parameter choice below.
+
+```{r run_bifrost_setup, eval=FALSE, message = TRUE}
+if (!exists("use_live_plot", inherits = TRUE)) {
+  use_live_plot <- FALSE
 }
 
 # ---- Run the search ----
@@ -176,21 +184,21 @@ set.seed(1)
 jaws_search <- searchOptimalConfiguration(
   baseline_tree              = fish.tree,
   trait_data                 = fish.data,
-  min_descendant_tips        = 10, #try 4 for higher resolution (but more CPU time)
+  min_descendant_tips        = 10, # try 4 for higher resolution (but more CPU time)
   num_cores                  = 4,
   shift_acceptance_threshold = 20,
   uncertaintyweights_par     = TRUE,
   IC                         = "GIC",
-  plot                       = FALSE,
+  plot                       = use_live_plot,
   formula                    = "trait_data ~ 1",
-  method                     = "H&L",   # penalized likelihood for high-dimensional data
+  method                     = "H&L", # penalized likelihood for high-dimensional data
   error                      = TRUE,
   store_model_fit_history    = TRUE,
   verbose                    = TRUE
 )
 
-# Restore environment variables
-on.exit({
+# Restore environment variables if the optional thread block above was run
+if (exists("old_threads", inherits = FALSE)) {
   for (nm in names(old_threads)) {
     val <- old_threads[[nm]]
     if (is.na(val) || val == "") {
@@ -199,43 +207,76 @@ on.exit({
       do.call(Sys.setenv, setNames(list(val), nm))
     }
   }
-}, add = TRUE)
-
+}
 ```
 
 ### Understanding the primary input options
 
-Let's explore the choices made in this function call:
+The table below gives a quick reference for the main choices made in this function call. The notes that follow focus on the rationale and caveats behind the less self-explanatory options.
 
-  * `baseline_tree = fish.tree`: This is our starting point—a phylogenetic tree. Internally, all branches are assigned to a single, baseline regime (labeled "0"). The function will search for shifts *away* from this null model.
+| Option | Value here | What it controls |
+|:--|:--|:--|
+| `baseline_tree` | `fish.tree` | The starting phylogeny and single-regime null model |
+| `trait_data` | `fish.data` | The multivariate trait matrix analyzed by the model |
+| `min_descendant_tips` | `10` | The minimum clade size considered for candidate shifts |
+| `num_cores` | `4` | The number of CPU cores used to evaluate candidate shift models in parallel |
+| `shift_acceptance_threshold` | `20` | The IC improvement required to accept a new shift |
+| `uncertaintyweights_par` | `TRUE` | Whether to estimate post-hoc support for accepted shifts in parallel |
+| `IC` | `"GIC"` | The information criterion used to compare candidate models |
+| `plot` | `use_live_plot` (`FALSE` here) | Whether to plot accepted shifts during the search |
+| `formula` | `"trait_data ~ 1"` | The multivariate GLS model structure |
+| `method` | `"H&L"` | The `mvMORPH::mvgls` fitting method |
+| `error` | `TRUE` | Whether to estimate and include measurement error |
+| `store_model_fit_history` | `TRUE` | Whether to write per-iteration model fits to temporary storage |
+| `verbose` | `TRUE` | Whether to print progress messages via `message()` as candidates are generated and evaluated |
+
+Some choices deserve additional context:
+
+  * `baseline_tree = fish.tree`: Internally, all branches start in a single baseline regime (labeled "0"). The function searches for shifts *away* from this null model.
   
-  * `trait_data = fish.data`: This is the matrix of our high-dimensional jaw shape data. The function will model the evolution of these traits.
+  * `trait_data = fish.data`: These are the high-dimensional jaw shape coordinates modeled as the multivariate response.
   
-  * `min_descendant_tips = 10`: This is a user defined constraint. It tells the function to only consider potential shifts on internal nodes that lead to a clade with at least 10 species. This seeks to reduce overfitting by preventing shifts on very small clades. We use 10 in this example, but the optimal choice here will depend on a given dataset (~10 is recommended for large trees).
+  * `min_descendant_tips = 10`: This user-defined constraint limits candidate shifts to internal nodes leading to at least 10 species. It helps reduce overfitting by preventing shifts on very small clades. We use 10 here, but the optimal choice depends on the dataset (~10 is recommended for large trees).
+
+  * `num_cores = 4`: When `num_cores > 1`, *`bifrost`* uses `future` workers for parallel candidate scoring and parallel IC-weight calculations. Only those future-based parallel blocks temporarily cap BLAS/OpenMP threads to 1 per worker to avoid CPU oversubscription, then restore the previous settings. Sequential `mvgls` stages, such as the baseline fit and later greedy-search refits, use the BLAS/OpenMP settings already active in the R session; set those outside the search call if you want a higher cap for sequential linear algebra.
   
-  * `num_cores = 4`: To speed up the search, the function evaluates all candidate shift models in parallel. We've specified using 4 CPU cores for this task.
+  * `shift_acceptance_threshold = 20`: This is the core of the greedy algorithm. A potential shift is accepted only if it improves fit by at least 20 IC units (GIC units here), reducing the risk of spurious shifts.
   
-  * `shift_acceptance_threshold = 20`: This is the core of the greedy algorithm. A potential new shift is only accepted if it improves the model fit by at least 20 IC units (GIC units). This threshold ensures that only shifts with strong support are added to the model, reducing the risk of spurious shifts (false positives).
+  * `uncertaintyweights_par = TRUE`: After the greedy search identifies an optimal shift configuration, the final model is refit repeatedly with each accepted shift removed in turn. The resulting IC weights quantify support for individual shifts in the context of the final model. The `_par` suffix indicates that this step is done in parallel.
   
-  * `uncertaintyweights_par = TRUE`: After the greedy search identifies an optimal configuration of shifts, this option triggers a post-hoc analysis to quantify the importance of each accepted shift. It refits the final model repeatedly, each time with a focal shift removed, and calculates an Information Criterion (IC) weight for each shift. This helps assess how much evidence supports each individual shift in the context of the final model. The `_par` suffix indicates this will be done in parallel.
-  
-  * `IC = "GIC"`: We have chosen the **Generalized Information Criterion** to evaluate model fit. GIC is generally preferred for high-dimensional data (like our landmark data) compared to alternatives like AIC or BIC.
+  * `IC = "GIC"`: The **Generalized Information Criterion** is generally preferred for high-dimensional data (like our landmark data) compared to alternatives like AIC or BIC.
     
-  * `plot = FALSE`: This is a helpful option for visualizing the search in real-time. The function will plot the tree and label the shifts as they are accepted, but this will slow down the search. Useful for small tests.
+  * `plot = use_live_plot`: Real-time plotting can be useful for small tests because it shows the tree and labels shifts as they are accepted, but it slows down larger searches. Here `use_live_plot` defaults to `FALSE`.
   
-  * `formula = "trait_data ~ 1"`: This specifies the structure of the underlying GLS model. Here, we fit a simple intercept-only model (`~ 1`), which corresponds to a multi-rate Brownian Motion process where each regime has its own rate matrix. Morphometric coordinates that have been GPA aligned are size and rotation adjusted, so no size adjustment is required. For linear dimensions or other predictors, you can use more general formulas that reference subsets of `trait_data`, for example `"trait_data[, 1:5] ~ 1"` to treat columns 1–5 as the multivariate response, or `"trait_data[, 2:ncol(trait_data)] ~ trait_data[, 1]"` if the first column is log-mass and the remaining columns are logged linear dimensions.
+  * `formula = "trait_data ~ 1"`: The intercept-only model (`~ 1`) corresponds to a multi-rate Brownian Motion process where each regime has its own rate matrix. The GPA-aligned morphometric coordinates are already size and rotation adjusted, so no additional size term is needed here. For linear dimensions or other predictors, you can use formulas that reference subsets of `trait_data`, for example `"trait_data[, 1:5] ~ 1"` to treat columns 1–5 as the multivariate response, or `"trait_data[, 2:ncol(trait_data)] ~ trait_data[, 1]"` if the first column is log-mass and the remaining columns are logged linear dimensions.
   
-  * `method = 'H&L'`: This specifies the likelihood fitting method passed to `mvMORPH::mvgls`. 'H\&L' is a fast, approximated leave-one-out cross-validation (LOOCV) approach based on the work of Hoffbeck and Landgrebe (1996). It is effective for intercept-only models with a "RidgeArch" default penalty, making it a reasonable choice for this high-dimensional dataset. Other options passed to `mvgls` will depend on the nature of the input dataset.
+  * `method = "H&L"`: H\&L is a fast, approximated leave-one-out cross-validation (LOOCV) approach based on Hoffbeck and Landgrebe (1996). It is effective for intercept-only models with a "RidgeArch" default penalty, making it a reasonable choice for this high-dimensional dataset. Other options passed to `mvgls` will depend on the nature of the input dataset.
   
-  * `error = TRUE`: This argument tells `mvgls` to estimate a measurement-error (intra-specific variance) term from the data and incorporate it into the model. Even if no explicit measurement-error values are provided, the function will treat this variance as an additional parameter to estimate. This is recommended for empirical datasets to account for within-species variation.
+  * `error = TRUE`: `mvgls` estimates a measurement-error (intra-specific variance) term and incorporates it into the model. Even without explicit measurement-error values, the function treats this variance as an additional parameter, which is recommended for empirical datasets with within-species variation.
 
   * `store_model_fit_history = TRUE`: Write per-iteration model fits to a temporary directory (`tempdir()`) during the search to avoid inflating memory usage while computation is ongoing; the full model-fit history is read back into memory at the end of the search.
 
-  * `verbose = TRUE`: Print progress messages (via `message()`) as candidate models are generated and evaluated.
-
 ## Interpreting the Output
 
-The `searchOptimalConfiguration` function returns a list containing detailed results of the search.
+The static figures in this vignette use the same jaw-shape search settings shown above. For the cached threshold-20 run used here, the selected model retained 17 shifts and improved the GIC by more than 7,000 units relative to the single-regime baseline.
+
+| Result | Value |
+|:--|:--|
+| Accepted shifts | 17 |
+| Accepted shift nodes | 107, 113, 115, 94, 128, 129, 158, 157, 98, 161, 92, 89, 93, 96, 97, 108, 116 |
+| Baseline GIC | -335266.29 |
+| Optimal GIC | -342739.42 |
+| GIC improvement (`baseline_ic - optimal_ic`) | 7473.13 |
+
+The `searchOptimalConfiguration()` result is a named list. These are the main components to inspect first:
+
+| Component | Interpretation |
+|:--|:--|
+| `shift_nodes_no_uncertainty` | Integer node numbers where shifts were accepted in the selected no-uncertainty configuration |
+| `baseline_ic` and `optimal_ic` | GIC scores for the single-regime baseline and selected multi-regime model; lower IC is better |
+| `VCVs` | Regime-specific variance-covariance matrices, including the baseline regime `"0"` |
+| `ic_weights` | Drop-one support values for individual shifts when `uncertaintyweights_par = TRUE` |
+| `model_fit_history` | Per-iteration model fits used by `icTrajectory()` to diagnose search behavior |
 
 ```{r print_method_demo, eval=FALSE}
 # The bifrost_search object has a custom S3 print method:
@@ -243,12 +284,9 @@ The `searchOptimalConfiguration` function returns a list containing detailed res
 jaws_search
 ```
 
-Let's look at the key components:
+Let's look at the key components programmatically:
 
 ```{r interpret_results, eval=FALSE}
-
-# View the output of the results object
-
 # The node numbers where shifts were inferred and accepted
 print(jaws_search$shift_nodes_no_uncertainty)
 
@@ -256,8 +294,6 @@ print(jaws_search$shift_nodes_no_uncertainty)
 cat("Baseline GIC:", jaws_search$baseline_ic, "\n")
 cat("Optimal GIC:", jaws_search$optimal_ic, "\n")
 cat("Improvement (Delta GIC):", jaws_search$baseline_ic - jaws_search$optimal_ic, "\n")
-
-#The model fit improvement is > 7000 GIC units
 
 # The VCV matrices for each detected regime
 # This shows the estimated rates of evolution for each regime
@@ -268,24 +304,24 @@ heatmap(jaws_search$VCVs$`0`, labRow = "", labCol = "")
 # traits (for the 'root' regime)
 heatmap(cov2cor(jaws_search$VCVs$`0`), labRow = "", labCol = "")
 
-# The ic_weights sub-object stores detailed information about shift support (
-# if uncertaintyweights_par = TRUE)
-print(as.matrix(jaws_search$ic_weights)) #print as matrix in chunk
+# The ic_weights sub-object stores detailed information about shift support
+# if uncertaintyweights_par = TRUE.
+print(as.matrix(jaws_search$ic_weights))
 
-# Extract the shift node numbers with corresponding IC weights
-print(cbind(node=jaws_search$ic_weights$node, 
-            weight=jaws_search$ic_weights$ic_weight_withshift))
+# Extract the strongest-supported shift nodes and corresponding IC weights
+support <- jaws_search$ic_weights[order(
+  jaws_search$ic_weights$ic_weight_withshift,
+  decreasing = TRUE
+), c("node", "ic_weight_withshift")]
+print(head(support, 10))
 
 # Extract the nodes with weights > 95%
 print(with(jaws_search$ic_weights, {
   sel <- ic_weight_withshift > 0.95
   cbind(node = node[sel], weight = ic_weight_withshift[sel])
 }))
-
-# These nodes have very strong statistical support for shift events
-
 ```
-<br>
+
 ```{r cor_heatmap_fig, echo=FALSE, fig.align="center", out.width="60%", fig.alt="Heatmap of estimated evolutionary correlations for the root regime in the jaw-shape example."}
 knitr::include_graphics("jaw-shape/cor_heatmap.png")
 ```
@@ -317,14 +353,14 @@ plot(
 )
 
 ```
-<br>
+
 ```{r IC_decay_fig, echo=FALSE, fig.align="center", out.width="80%", fig.alt="Information-criterion trajectory across sequentially evaluated sub-models. Accepted shifts are shown as blue points, rejected shifts as red crosses, the running best IC as a blue step line, and the baseline IC as a black point. Proposal-level delta IC is also shown."}
 knitr::include_graphics("jaw-shape/IC_decay.png")
 ```
 
 > **Figure 4. Information-criterion trajectory for the jaw-shape search.** Information-criterion (IC) trajectory across sequentially evaluated sub-models during the greedy shift search. Blue points indicate accepted shifts, red crosses indicate rejected shifts, the blue step line tracks the running best IC, and the black point marks the baseline IC. The plot also shows proposal-level delta IC. Labels highlight the baseline and minimum accepted IC values.
 
-## Generating a preliminary branch-rate plot
+## Generating a branch-rate plot
 
 ```{r plot_tree, eval=FALSE}
 
@@ -356,34 +392,16 @@ xs <- seq(x0, x1, length.out = length(cols_ord) + 1L)
 rect(xs[-length(xs)], y0, xs[-1], y1, col = cols_ord, border = NA)
 rect(x0, y0, x1, y1, border = "grey30")
 
-min_rate <- min(rates); max_rate <- max(rates)
-ratio_int <- if (is.finite(min_rate) && min_rate > 0) 
-  as.integer(round(max_rate / min_rate)) else NA_integer_
-
 text((x0 + x1) / 2, y1 + vscale * (0.03 * yr), 
      "Mean rate (slow \u2192 fast)", cex = 0.9)
-
-#Vignette will be updated with additional plotting functions and post-hoc analyses
-
 ```
 
-<br>
 ```{r branch_rates_fig, echo=FALSE, fig.align="center", out.width="80%", fig.alt="Upward-oriented phylogenetic tree without tip labels. Branches are colored using a viridis gradient, where yellow branches represent faster inferred evolutionary rates and dark purple branches represent slower rates; different clades show distinct colors indicating variation in branch rates across the tree."}
 knitr::include_graphics("jaw-shape/branch_rates.png")
 ```
 
-> **Figure 5. Preliminary branch-rate visualization for the jaw-shape example.** SIMMAP-style phylogeny object from the jaw-shape example, with branches colored by inferred mean evolutionary rate under the selected multi-regime model. Branch colors follow a perceptually uniform viridis scale, with yellow indicating faster rates and dark purple indicating slower rates, highlighting variation in evolutionary tempo across the tree. Faster branches on the left side correspond to Dipnoi -- or lungfish; see Troyer et al. (2025).
-
-## Other key output
-
-  * `shift_nodes_no_uncertainty`: A vector of integer node numbers on the phylogeny where significant shifts in jaw shape evolution were detected.
-  
-  * `optimal_ic` and `baseline_ic`: These values show the GIC score for the final multi-regime model and the initial single-regime model, respectively. The difference represents the total improvement in model fit achieved by adding the shifts.
-  
-  * `VCVs`: A list of variance-covariance matrices, one for each detected regime (including the baseline "0" regime). The elements of these matrices represent the evolutionary rates and covariances for the jaw shape traits. By comparing the matrices (e.g., by looking at their trace), we can quantify *how much faster* evolution was in one regime compared to another.
-  
-  * `ic_weights`: A dataframe showing the evidence supporting each individual shift. Higher weights (closer to 1.0) indicate that a given shift is essential for the overall model's explanatory power.
+> **Figure 5. Branch-rate visualization for the jaw-shape example.** SIMMAP-style phylogeny object from the jaw-shape example, with branches colored by inferred mean evolutionary rate under the selected multi-regime model. Branch colors follow a perceptually uniform viridis scale, with yellow indicating faster rates and dark purple indicating slower rates, highlighting variation in evolutionary tempo across the tree. Faster branches on the left side correspond to Dipnoi -- or lungfish; see Troyer et al. (2025).
 
 ## Conclusion
 
-This vignette demonstrates how to use the *`bifrost`* package to analyze a complex, high-dimensional dataset to find significant shifts in evolutionary dynamics. Applying `searchOptimalConfiguration` to a Paleozoic fish jaw dataset, we infer cladogenic events that correspond with significant shifts in  multivariate phenotypic evolution, similar to the hypotheses presented in Troyer et al. (2025). This workflow allows us not only to identify *where* shifts occurred but also to quantify the *magnitude* of the change in evolutionary rates through the VCV matrices (the topic of a separate vignette).
+This vignette demonstrates how to use the *`bifrost`* package to analyze a complex, high-dimensional dataset to find significant shifts in evolutionary dynamics. Applying `searchOptimalConfiguration()` to a Paleozoic fish jaw dataset, we infer cladogenic events that correspond with significant shifts in multivariate phenotypic evolution, similar to the hypotheses presented in Troyer et al. (2025). This workflow allows us not only to identify *where* shifts occurred but also to quantify the *magnitude* of the change in evolutionary rates through the VCV matrices. For a deeper look at branch-rate summaries and threshold sensitivity in this same dataset, continue to the [rate-map jaw-shape vignette](rate-map-jaw-shape-vignette.html).


### PR DESCRIPTION
## Summary

- Add a quick-reference table for the primary `searchOptimalConfiguration()` options.
- Streamline the detailed option notes while preserving unique guidance.
- Improve the output interpretation section with cached run summary values and a returned-object component table.
- Clarify optional runtime setup, including BLAS/OpenMP behavior for sequential versus parallel portions of the search.

## Validation

- Rendered `vignettes/jaw-shape-vignette.Rmd` successfully with `rmarkdown::render(...)`.
- Ran `git diff --check` successfully.