### PR TITLE
[codex] Draw rateMap category legends proportional to breaks

### DIFF
--- a/R/rate-map-plot.R
+++ b/R/rate-map-plot.R
@@ -102,6 +102,7 @@
       length(n_colors) != 1L ||
       !is.finite(n_colors) ||
       n_colors < 1L ||
+      n_colors != as.integer(n_colors) ||
       length(breaks) != as.integer(n_colors) + 1L ||
       any(!is.finite(breaks)) ||
       is.unsorted(breaks, strictly = TRUE) ||

--- a/R/rate-map-plot.R
+++ b/R/rate-map-plot.R
@@ -96,6 +96,51 @@
   markers
 }
 
+.rateMap_category_legend_breaks <- function(breaks, n_colors) {
+  if (!is.numeric(breaks) ||
+      !is.numeric(n_colors) ||
+      length(n_colors) != 1L ||
+      !is.finite(n_colors) ||
+      n_colors < 1L ||
+      length(breaks) != as.integer(n_colors) + 1L ||
+      any(!is.finite(breaks)) ||
+      is.unsorted(breaks, strictly = TRUE) ||
+      diff(range(breaks)) <= 0) {
+    return(NULL)
+  }
+
+  breaks
+}
+
+.rateMap_category_legend_x <- function(breaks, x0, x1, direction = "rightwards") {
+  legend <- x1 - x0
+  frac <- (breaks - min(breaks)) / diff(range(breaks))
+  if (identical(direction, "leftwards")) {
+    x1 - frac * legend
+  } else {
+    x0 + frac * legend
+  }
+}
+
+.rateMap_category_legend_label_index <- function(labels, tick_x, fsize) {
+  n_labels <- length(labels)
+  if (n_labels <= 2L) {
+    return(seq_len(n_labels))
+  }
+
+  label_widths <- graphics::strwidth(labels, cex = fsize)
+  tick_order <- order(tick_x)
+  gap <- diff(tick_x[tick_order])
+  ordered_widths <- label_widths[tick_order]
+  fits <- all((utils::head(ordered_widths, -1L) + utils::tail(ordered_widths, -1L)) / 2 <=
+                0.9 * gap)
+  if (isTRUE(fits)) {
+    seq_len(n_labels)
+  } else {
+    c(1L, n_labels)
+  }
+}
+
 .rateMap_add_category_legend <- function(x,
                                          legend,
                                          x_pos,
@@ -189,29 +234,52 @@
     )
   } else {
     bar_cols <- x$cols
-    if (length(bar_cols) == 1L) {
-      bar_cols <- rep(bar_cols, 2L)
+    legend_breaks <- .rateMap_category_legend_breaks(x$category_breaks, length(bar_cols))
+    if (!is.null(legend_breaks)) {
+      xs <- .rateMap_category_legend_x(legend_breaks, x0, x1, direction)
+      graphics::rect(
+        pmin(utils::head(xs, -1L), utils::tail(xs, -1L)),
+        y0,
+        pmax(utils::head(xs, -1L), utils::tail(xs, -1L)),
+        y1,
+        col = unname(bar_cols),
+        border = NA
+      )
+      graphics::segments(xs, y0, xs, y1, col = "grey20", lwd = 0.5)
+      break_labels <- formatC(legend_breaks, digits = digits, format = "fg")
+      label_index <- .rateMap_category_legend_label_index(break_labels, xs, fsize)
+      graphics::text(
+        xs[label_index],
+        rep(y1 + label_gap, length(label_index)),
+        labels = break_labels[label_index],
+        cex = fsize,
+        adj = c(0.5, 0.5)
+      )
+    } else {
+      if (length(bar_cols) == 1L) {
+        bar_cols <- rep(bar_cols, 2L)
+      }
+      if (identical(direction, "leftwards")) {
+        bar_cols <- rev(bar_cols)
+        lims <- rev(lims)
+      }
+      xs <- seq(x0, x1, length.out = length(bar_cols) + 1L)
+      graphics::rect(
+        xs[-length(xs)],
+        y0,
+        xs[-1L],
+        y1,
+        col = unname(bar_cols),
+        border = NA
+      )
+      graphics::text(
+        c(x0, x1),
+        rep(y1 + label_gap, 2L),
+        labels = formatC(lims, digits = digits, format = "fg"),
+        cex = fsize,
+        adj = c(0.5, 0.5)
+      )
     }
-    if (identical(direction, "leftwards")) {
-      bar_cols <- rev(bar_cols)
-      lims <- rev(lims)
-    }
-    xs <- seq(x0, x1, length.out = length(bar_cols) + 1L)
-    graphics::rect(
-      xs[-length(xs)],
-      y0,
-      xs[-1L],
-      y1,
-      col = unname(bar_cols),
-      border = NA
-    )
-    graphics::text(
-      c(x0, x1),
-      rep(y1 + label_gap, 2L),
-      labels = formatC(lims, digits = digits, format = "fg"),
-      cex = fsize,
-      adj = c(0.5, 0.5)
-    )
   }
   if (isTRUE(outline)) {
     graphics::rect(x0, y0, x1, y1, border = "grey30")
@@ -498,6 +566,8 @@
 #' @param category_bin_method Optional automatic category-binning method:
 #'   `"pretty"` or `"equal"`.
 #' @param category_breaks Optional strictly increasing category boundaries.
+#'   Category legends draw valid numeric interval breaks with proportional
+#'   segment widths.
 #' @param category_labels Optional labels for displayed categories.
 #' @param ncolors Optional number of colors for continuous ramps. If omitted,
 #'   the stored `x$ncolors` value is used, falling back to `256` for older
@@ -928,7 +998,9 @@ rateMapView <- function(x,
 #'   for equal-width numeric intervals. Ignored when `category_breaks` is
 #'   supplied.
 #' @param category_breaks Optional category-break override for
-#'   `color_mode = "category"`. Custom breaks override automatic bins.
+#'   `color_mode = "category"`. Custom breaks override automatic bins. Category
+#'   legends draw valid numeric interval breaks with proportional segment
+#'   widths.
 #' @param category_labels Optional category-label override for
 #'   `color_mode = "category"`.
 #' @param legend_title Optional legend title override for this plot.

--- a/man/plot.rateMap.Rd
+++ b/man/plot.rateMap.Rd
@@ -68,7 +68,8 @@ for equal-width numeric intervals. Ignored when \code{category_breaks} is
 supplied.}
 
 \item{category_breaks}{Optional category-break override for
-\code{color_mode = "category"}. Custom breaks override automatic bins.}
+\code{color_mode = "category"}. Custom breaks override automatic bins. Category
+legends draw valid numeric interval breaks with proportional segment widths.}
 
 \item{category_labels}{Optional category-label override for
 \code{color_mode = "category"}.}

--- a/man/plot.rateMap.Rd
+++ b/man/plot.rateMap.Rd
@@ -69,7 +69,8 @@ supplied.}
 
 \item{category_breaks}{Optional category-break override for
 \code{color_mode = "category"}. Custom breaks override automatic bins. Category
-legends draw valid numeric interval breaks with proportional segment widths.}
+legends draw valid numeric interval breaks with proportional segment
+widths.}
 
 \item{category_labels}{Optional category-label override for
 \code{color_mode = "category"}.}

--- a/man/rateMapView.Rd
+++ b/man/rateMapView.Rd
@@ -39,8 +39,8 @@ discrete ordered bins or \code{"continuous"} for a continuous ramp.}
 \code{"pretty"} or \code{"equal"}.}
 
 \item{category_breaks}{Optional strictly increasing category boundaries.
-Category legends draw valid numeric interval breaks with proportional segment
-widths.}
+Category legends draw valid numeric interval breaks with proportional
+segment widths.}
 
 \item{category_labels}{Optional labels for displayed categories.}
 

--- a/man/rateMapView.Rd
+++ b/man/rateMapView.Rd
@@ -38,7 +38,9 @@ discrete ordered bins or \code{"continuous"} for a continuous ramp.}
 \item{category_bin_method}{Optional automatic category-binning method:
 \code{"pretty"} or \code{"equal"}.}
 
-\item{category_breaks}{Optional strictly increasing category boundaries.}
+\item{category_breaks}{Optional strictly increasing category boundaries.
+Category legends draw valid numeric interval breaks with proportional segment
+widths.}
 
 \item{category_labels}{Optional labels for displayed categories.}
 

--- a/tests/testthat/test-rate-map.R
+++ b/tests/testthat/test-rate-map.R
@@ -1476,6 +1476,7 @@ test_that("rateMap palette resolution handles names, vectors, and reversal", {
   testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1), c(1L, 2L)))
   testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1), NA_real_))
   testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1), 0L))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1, 2), 2.2))
   testthat::expect_null(.rateMap_category_legend_breaks(c(1, 4), 2L))
   testthat::expect_null(.rateMap_category_legend_breaks(c(0, NA_real_, 1), 2L))
   testthat::expect_null(.rateMap_category_legend_breaks(c(0, 2, 2), 2L))

--- a/tests/testthat/test-rate-map.R
+++ b/tests/testthat/test-rate-map.R
@@ -1461,6 +1461,18 @@ test_that("rateMap palette resolution handles names, vectors, and reversal", {
     )),
     c(0.99, 1.01)
   )
+  fisher_breaks <- c(-14.22, -13.69, -13.21, -12.91, -12.57, -11.40, -10.57)
+  testthat::expect_equal(
+    .rateMap_category_legend_breaks(fisher_breaks, 6L),
+    fisher_breaks
+  )
+  xs <- .rateMap_category_legend_x(fisher_breaks, 0, 1)
+  testthat::expect_equal(diff(xs), diff(fisher_breaks) / diff(range(fisher_breaks)))
+  leftward_xs <- .rateMap_category_legend_x(fisher_breaks, 0, 1, "leftwards")
+  testthat::expect_equal(abs(diff(leftward_xs)), diff(xs))
+  testthat::expect_equal(leftward_xs[c(1L, length(leftward_xs))], c(1, 0))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(1, 4), 2L))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(0, 2, 2), 2L))
   testthat::expect_null(.rateMap_add_category_legend(list(rate_categories = NULL)))
   testthat::expect_equal(
     .rateMap_map_value(c("0" = 1), c("0" = 7), start = 2, end = 3),
@@ -1527,6 +1539,23 @@ test_that("rateMap uses progress/workers and plot() draws separately", {
       legend = 0.5,
       x_pos = 0.2,
       y_pos = 0.2
+    ))
+
+    testthat::expect_null(.rateMap_add_category_legend(
+      list(
+        rate_categories = data.frame(
+          lower = c(0, 2),
+          upper = c(2, 5),
+          value = c(NA_real_, NA_real_)
+        ),
+        cols = c(slow = "red", fast = "blue"),
+        category_breaks = c(0, 2, 5),
+        title = "custom categories",
+        lims = c(0, 5)
+      ),
+      legend = 0.5,
+      x_pos = 0.2,
+      y_pos = 0.3
     ))
 
     out <- .rate_map_eval_no_error(rateMap(

--- a/tests/testthat/test-rate-map.R
+++ b/tests/testthat/test-rate-map.R
@@ -1471,7 +1471,13 @@ test_that("rateMap palette resolution handles names, vectors, and reversal", {
   leftward_xs <- .rateMap_category_legend_x(fisher_breaks, 0, 1, "leftwards")
   testthat::expect_equal(abs(diff(leftward_xs)), diff(xs))
   testthat::expect_equal(leftward_xs[c(1L, length(leftward_xs))], c(1, 0))
+  testthat::expect_null(.rateMap_category_legend_breaks("not numeric", 1L))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1), "two"))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1), c(1L, 2L)))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1), NA_real_))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(0, 1), 0L))
   testthat::expect_null(.rateMap_category_legend_breaks(c(1, 4), 2L))
+  testthat::expect_null(.rateMap_category_legend_breaks(c(0, NA_real_, 1), 2L))
   testthat::expect_null(.rateMap_category_legend_breaks(c(0, 2, 2), 2L))
   testthat::expect_null(.rateMap_add_category_legend(list(rate_categories = NULL)))
   testthat::expect_equal(
@@ -1529,6 +1535,22 @@ test_that("rateMap uses progress/workers and plot() draws separately", {
   .rate_map_with_pdf({
     graphics::plot.new()
     graphics::plot.window(xlim = c(0, 1), ylim = c(0, 1))
+    testthat::expect_equal(
+      .rateMap_category_legend_label_index(c("0", "1"), c(0, 1), 1),
+      c(1L, 2L)
+    )
+    testthat::expect_equal(
+      .rateMap_category_legend_label_index(c("0", "1", "2"), c(0, 0.5, 1), 0.5),
+      1:3
+    )
+    testthat::expect_equal(
+      .rateMap_category_legend_label_index(
+        c("long left label", "long middle label", "long right label"),
+        c(0, 0.01, 0.02),
+        2
+      ),
+      c(1L, 3L)
+    )
     testthat::expect_null(.rateMap_add_category_legend(
       list(
         rate_categories = data.frame(lower = 1, upper = 1, value = 1),


### PR DESCRIPTION
## Summary

This PR fixes categorical `rateMap` legends when numeric interval `category_breaks` are supplied manually. The tree coloring was already using the supplied breaks, but the legend rendered every categorical interval as an equal-width swatch. That made uneven Fisher/Jenks-style intervals look evenly spaced.

## Changes

- Detect valid numeric categorical interval breaks in `.rateMap_add_category_legend()`.
- Draw categorical legend segments proportional to the numeric interval widths.
- Preserve the existing equal-width fallback for exact-value, nominal, missing, or invalid category breaks.
- Keep leftward legend orientation aligned with the existing color mapping.
- Document the proportional legend behavior for `rateMapView()` and `plot.rateMap()`.
- Add tests for Fisher-style break geometry, leftward orientation, invalid-break fallback, and the drawing path.

## Validation

```sh
Rscript -e "pkgload::load_all('.'); testthat::test_file('tests/testthat/test-rate-map.R')"
```

This branch is intentionally legend-only and does not include the local simulation-study work.