### PR TITLE
Speed up Colab notebook setup

### DIFF
--- a/tools/build-colab-notebook.py
+++ b/tools/build-colab-notebook.py
@@ -17,6 +17,10 @@ COLAB_BASE = "https://colab.research.google.com/github/jakeberv/bifrost/blob/mai
 COLAB_BADGE = "https://colab.research.google.com/assets/colab-badge.svg"
 RAW_BASE = "https://raw.githubusercontent.com/jakeberv/bifrost/main/vignettes"
 PKGDOWN_ARTICLES = "https://jakeberv.com/bifrost/articles"
+COMMON_COLAB_PACKAGES = ("remotes", "knitr")
+COLAB_PACKAGES_BY_SLUG = {
+    "pca-model-selection-and-bifrost-vignette": ("phylolm",),
+}
 
 
 def find_repo_root(start: Path) -> Path:
@@ -179,14 +183,20 @@ def rewrite_markdown_links(markdown: str) -> str:
     )
 
 
-def setup_source() -> str:
-    return """if (!dir.exists("/content/bifrost")) {
+def setup_source(slug: str) -> str:
+    packages = COMMON_COLAB_PACKAGES + COLAB_PACKAGES_BY_SLUG.get(slug, ())
+    package_vector = ", ".join(json.dumps(package) for package in packages)
+    return f"""if (!dir.exists("/content/bifrost")) {{
   system("git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost")
-}
-if (!requireNamespace("remotes", quietly = TRUE)) {
-  install.packages("remotes", repos = "https://cloud.r-project.org")
-}
-remotes::install_local("/content/bifrost", dependencies = TRUE, upgrade = "never")
+}}
+colab_packages <- c({package_vector})
+missing_packages <- colab_packages[
+  !vapply(colab_packages, requireNamespace, logical(1), quietly = TRUE)
+]
+if (length(missing_packages)) {{
+  install.packages(missing_packages, repos = "https://cloud.r-project.org")
+}}
+remotes::install_local("/content/bifrost", dependencies = NA, upgrade = "never")
 setwd("/content/bifrost/vignettes")
 """
 
@@ -205,7 +215,7 @@ def convert(slug: str, repo_root: Path) -> dict:
             f"{colab_badge_markdown(slug)}\n\n"
             f"Converted from [`vignettes/{slug}.Rmd`]({REPO}/blob/main/vignettes/{slug}.Rmd)."
         ),
-        code_cell(setup_source()),
+        code_cell(setup_source(slug)),
     ]
 
     default_eval_false = False

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -153,6 +153,22 @@ def main() -> None:
             raise AssertionError(
                 f"{notebook_path.name} setup must use a shallow Git clone"
             )
+        if "dependencies = NA" not in setup or "dependencies = TRUE" in setup:
+            raise AssertionError(
+                f"{notebook_path.name} setup must install only hard package dependencies"
+            )
+        if '"knitr"' not in setup:
+            raise AssertionError(
+                f"{notebook_path.name} setup must install the shared knitr dependency"
+            )
+
+        expects_phylolm = (
+            notebook_path.stem == "pca-model-selection-and-bifrost-vignette"
+        )
+        if ('"phylolm"' in setup) != expects_phylolm:
+            raise AssertionError(
+                f"{notebook_path.name} setup has the wrong vignette-specific dependencies"
+            )
 
     with tempfile.TemporaryDirectory(prefix="bifrost-artifact-tests-") as temp:
         repo = Path(temp) / "repo"

--- a/vignettes/colab/jaw-shape-vignette.ipynb
+++ b/vignettes/colab/jaw-shape-vignette.ipynb
@@ -10,7 +10,7 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\nif (!requireNamespace(\"remotes\", quietly = TRUE)) {\n  install.packages(\"remotes\", repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = TRUE, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
+      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\ncolab_packages <- c(\"remotes\", \"knitr\")\nmissing_packages <- colab_packages[\n  !vapply(colab_packages, requireNamespace, logical(1), quietly = TRUE)\n]\nif (length(missing_packages)) {\n  install.packages(missing_packages, repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = NA, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
     },
     {
       "cell_type": "code",

--- a/vignettes/colab/pca-model-selection-and-bifrost-vignette.ipynb
+++ b/vignettes/colab/pca-model-selection-and-bifrost-vignette.ipynb
@@ -10,7 +10,7 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\nif (!requireNamespace(\"remotes\", quietly = TRUE)) {\n  install.packages(\"remotes\", repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = TRUE, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
+      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\ncolab_packages <- c(\"remotes\", \"knitr\", \"phylolm\")\nmissing_packages <- colab_packages[\n  !vapply(colab_packages, requireNamespace, logical(1), quietly = TRUE)\n]\nif (length(missing_packages)) {\n  install.packages(missing_packages, repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = NA, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
     },
     {
       "cell_type": "code",

--- a/vignettes/colab/quick-start-vignette.ipynb
+++ b/vignettes/colab/quick-start-vignette.ipynb
@@ -10,7 +10,7 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\nif (!requireNamespace(\"remotes\", quietly = TRUE)) {\n  install.packages(\"remotes\", repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = TRUE, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
+      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\ncolab_packages <- c(\"remotes\", \"knitr\")\nmissing_packages <- colab_packages[\n  !vapply(colab_packages, requireNamespace, logical(1), quietly = TRUE)\n]\nif (length(missing_packages)) {\n  install.packages(missing_packages, repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = NA, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
     },
     {
       "cell_type": "code",

--- a/vignettes/colab/rate-map-jaw-shape-part-2-comparisons.ipynb
+++ b/vignettes/colab/rate-map-jaw-shape-part-2-comparisons.ipynb
@@ -10,7 +10,7 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\nif (!requireNamespace(\"remotes\", quietly = TRUE)) {\n  install.packages(\"remotes\", repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = TRUE, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
+      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\ncolab_packages <- c(\"remotes\", \"knitr\")\nmissing_packages <- colab_packages[\n  !vapply(colab_packages, requireNamespace, logical(1), quietly = TRUE)\n]\nif (length(missing_packages)) {\n  install.packages(missing_packages, repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = NA, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
     },
     {
       "cell_type": "code",

--- a/vignettes/colab/rate-map-jaw-shape-vignette.ipynb
+++ b/vignettes/colab/rate-map-jaw-shape-vignette.ipynb
@@ -10,7 +10,7 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\nif (!requireNamespace(\"remotes\", quietly = TRUE)) {\n  install.packages(\"remotes\", repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = TRUE, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
+      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\ncolab_packages <- c(\"remotes\", \"knitr\")\nmissing_packages <- colab_packages[\n  !vapply(colab_packages, requireNamespace, logical(1), quietly = TRUE)\n]\nif (length(missing_packages)) {\n  install.packages(missing_packages, repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = NA, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
     },
     {
       "cell_type": "code",

--- a/vignettes/colab/theoretical-background-vignette.ipynb
+++ b/vignettes/colab/theoretical-background-vignette.ipynb
@@ -10,7 +10,7 @@
       "execution_count": null,
       "metadata": {},
       "outputs": [],
-      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\nif (!requireNamespace(\"remotes\", quietly = TRUE)) {\n  install.packages(\"remotes\", repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = TRUE, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
+      "source": "if (!dir.exists(\"/content/bifrost\")) {\n  system(\"git clone --depth 1 https://github.com/jakeberv/bifrost.git /content/bifrost\")\n}\ncolab_packages <- c(\"remotes\", \"knitr\")\nmissing_packages <- colab_packages[\n  !vapply(colab_packages, requireNamespace, logical(1), quietly = TRUE)\n]\nif (length(missing_packages)) {\n  install.packages(missing_packages, repos = \"https://cloud.r-project.org\")\n}\nremotes::install_local(\"/content/bifrost\", dependencies = NA, upgrade = \"never\")\nsetwd(\"/content/bifrost/vignettes\")\n"
     },
     {
       "cell_type": "code",


### PR DESCRIPTION
## Summary

- install only bifrost hard dependencies in generated Colab notebooks
- bootstrap shared notebook tooling once and add `phylolm` only for the PCA vignette
- regenerate all committed notebooks and add regression coverage for the lean setup

## Why

The previous `dependencies = TRUE` setting installed all packages in `Suggests`, causing Colab to download more than 100 packages before a vignette could run. `dependencies = NA` retains required package dependencies while skipping unrelated optional packages.

## Verification

- `python3 tools/test-vignette-artifacts.py`
- `python3 -m py_compile tools/build-colab-notebook.py tools/test-vignette-artifacts.py`
- parsed every generated setup cell with R
- regenerated all notebooks and confirmed a clean deterministic result
- `git diff --check`