### PR TITLE
Auto-detect Colab notebook dependencies

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .cache/vignette-artifacts
-          key: vignette-pdfs-${{ runner.os }}-${{ hashFiles('vignettes/**/*.Rmd', 'vignettes/**/*.png', 'vignettes/**/*.gif', 'vignettes/**/*.jpg', 'vignettes/**/*.jpeg', 'vignettes/**/*.svg', 'vignettes/**/*.csv', 'vignettes/**/*.txt', 'vignettes/**/*.rds', 'vignettes/**/*.RDS', 'vignettes/**/*.R', 'R/**', 'inst/extdata/**', 'DESCRIPTION', '_pkgdown.yml', '.github/workflows/pkgdown.yml', 'tools/vignette_artifacts.R', 'tools/render-vignette-pdf.R', 'tools/build-colab-notebook.py', 'tools/test-vignette-artifacts.py') }}
+          key: vignette-pdfs-${{ runner.os }}-${{ hashFiles('vignettes/**/*.Rmd', 'vignettes/**/*.png', 'vignettes/**/*.gif', 'vignettes/**/*.jpg', 'vignettes/**/*.jpeg', 'vignettes/**/*.svg', 'vignettes/**/*.csv', 'vignettes/**/*.txt', 'vignettes/**/*.rds', 'vignettes/**/*.RDS', 'vignettes/**/*.R', 'R/**', 'inst/extdata/**', 'DESCRIPTION', '_pkgdown.yml', '.github/workflows/pkgdown.yml', 'tools/vignette_artifacts.R', 'tools/render-vignette-pdf.R', 'tools/build-colab-notebook.py', 'tools/colab_dependencies.py', 'tools/test-vignette-artifacts.py') }}
           restore-keys: |
             vignette-pdfs-${{ runner.os }}-
 

--- a/.github/workflows/vignette-artifacts.yml
+++ b/.github/workflows/vignette-artifacts.yml
@@ -12,6 +12,7 @@ on:
       - tools/vignette_artifacts.R
       - tools/render-vignette-pdf.R
       - tools/build-colab-notebook.py
+      - tools/colab_dependencies.py
       - tools/test-vignette-artifacts.py
       - vignettes/**
 

--- a/tools/build-colab-notebook.py
+++ b/tools/build-colab-notebook.py
@@ -7,10 +7,16 @@ import argparse
 import json
 import os
 import re
-import subprocess
 import sys
 import urllib.parse
 from pathlib import Path
+
+from colab_dependencies import (
+    BASE_R_PACKAGES,
+    COMMON_COLAB_PACKAGES,
+    description_hard_dependencies,
+    referenced_r_packages,
+)
 
 
 REPO = "https://github.com/jakeberv/bifrost"
@@ -24,57 +30,6 @@ RUNTIME_NOTE = (
     "uses the runtime's host CPUs, not the TPU itself. Otherwise, choose the "
     "available runtime with the most CPUs."
 )
-BASE_R_PACKAGES = {
-    "base",
-    "compiler",
-    "datasets",
-    "graphics",
-    "grDevices",
-    "grid",
-    "methods",
-    "parallel",
-    "splines",
-    "stats",
-    "stats4",
-    "tcltk",
-    "tools",
-    "utils",
-}
-COMMON_COLAB_PACKAGES = ("remotes", "knitr")
-
-R_PACKAGE_REFERENCE_SCRIPT = r"""
-code <- paste(readLines(file("stdin"), warn = FALSE), collapse = "\n")
-expressions <- parse(text = code)
-packages <- character()
-
-walk <- function(node) {
-  if (is.call(node)) {
-    operator <- node[[1L]]
-    if (is.symbol(operator)) {
-      operator_name <- as.character(operator)
-      if (operator_name %in% c("::", ":::") && length(node) >= 3L) {
-        packages <<- c(packages, as.character(node[[2L]]))
-      }
-      if (operator_name %in% c("library", "require") &&
-          length(node) >= 2L &&
-          (is.symbol(node[[2L]]) || is.character(node[[2L]]))) {
-        packages <<- c(packages, as.character(node[[2L]]))
-      }
-      if (operator_name %in% c("requireNamespace", "loadNamespace") &&
-          length(node) >= 2L && is.character(node[[2L]])) {
-        packages <<- c(packages, as.character(node[[2L]]))
-      }
-    }
-    invisible(lapply(as.list(node), walk))
-  } else if (is.expression(node) || is.pairlist(node)) {
-    invisible(lapply(as.list(node), walk))
-  }
-}
-
-walk(expressions)
-cat(sort(unique(packages)), sep = "\n")
-"""
-
 
 def find_repo_root(start: Path) -> Path:
     path = start.resolve()
@@ -87,45 +42,6 @@ def find_repo_root(start: Path) -> Path:
 def discover_slugs(repo_root: Path) -> list[str]:
     rmds = sorted((repo_root / "vignettes").glob("*.Rmd"))
     return [path.stem for path in rmds]
-
-
-def description_hard_dependencies(path: Path) -> set[str]:
-    fields: dict[str, list[str]] = {}
-    current = ""
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if line[:1].isspace() and current:
-            fields[current].append(line.strip())
-            continue
-        if ":" not in line:
-            current = ""
-            continue
-        current, value = line.split(":", 1)
-        fields[current] = [value.strip()]
-
-    packages: set[str] = set()
-    for field in ("Depends", "Imports", "LinkingTo"):
-        for entry in ",".join(fields.get(field, [])).split(","):
-            match = re.match(r"\s*([A-Za-z][A-Za-z0-9.]*)", entry)
-            if match and match.group(1) != "R":
-                packages.add(match.group(1))
-    return packages
-
-
-def referenced_r_packages(repo_root: Path, code: str) -> set[str]:
-    try:
-        result = subprocess.run(
-            ["Rscript", "--vanilla", "-e", R_PACKAGE_REFERENCE_SCRIPT],
-            cwd=repo_root,
-            input=code,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-    except FileNotFoundError as error:
-        raise SystemExit("Rscript is required to detect Colab dependencies") from error
-    if result.returncode != 0:
-        raise SystemExit(f"Could not parse vignette R code:\n{result.stderr}")
-    return set(result.stdout.split())
 
 
 def colab_packages(repo_root: Path, cells: list[dict]) -> tuple[str, ...]:

--- a/tools/build-colab-notebook.py
+++ b/tools/build-colab-notebook.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 import urllib.parse
 from pathlib import Path
@@ -23,12 +24,56 @@ RUNTIME_NOTE = (
     "uses the runtime's host CPUs, not the TPU itself. Otherwise, choose the "
     "available runtime with the most CPUs."
 )
-COMMON_COLAB_PACKAGES = ("remotes", "knitr")
-COLAB_PACKAGES_BY_SLUG = {
-    "jaw-shape-vignette": ("geomorph",),
-    "pca-model-selection-and-bifrost-vignette": ("phylolm",),
-    "rate-map-jaw-shape-vignette": ("geomorph",),
+BASE_R_PACKAGES = {
+    "base",
+    "compiler",
+    "datasets",
+    "graphics",
+    "grDevices",
+    "grid",
+    "methods",
+    "parallel",
+    "splines",
+    "stats",
+    "stats4",
+    "tcltk",
+    "tools",
+    "utils",
 }
+COMMON_COLAB_PACKAGES = ("remotes", "knitr")
+
+R_PACKAGE_REFERENCE_SCRIPT = r"""
+code <- paste(readLines(file("stdin"), warn = FALSE), collapse = "\n")
+expressions <- parse(text = code)
+packages <- character()
+
+walk <- function(node) {
+  if (is.call(node)) {
+    operator <- node[[1L]]
+    if (is.symbol(operator)) {
+      operator_name <- as.character(operator)
+      if (operator_name %in% c("::", ":::") && length(node) >= 3L) {
+        packages <<- c(packages, as.character(node[[2L]]))
+      }
+      if (operator_name %in% c("library", "require") &&
+          length(node) >= 2L &&
+          (is.symbol(node[[2L]]) || is.character(node[[2L]]))) {
+        packages <<- c(packages, as.character(node[[2L]]))
+      }
+      if (operator_name %in% c("requireNamespace", "loadNamespace") &&
+          length(node) >= 2L && is.character(node[[2L]])) {
+        packages <<- c(packages, as.character(node[[2L]]))
+      }
+    }
+    invisible(lapply(as.list(node), walk))
+  } else if (is.expression(node) || is.pairlist(node)) {
+    invisible(lapply(as.list(node), walk))
+  }
+}
+
+walk(expressions)
+cat(sort(unique(packages)), sep = "\n")
+"""
 
 
 def find_repo_root(start: Path) -> Path:
@@ -42,6 +87,60 @@ def find_repo_root(start: Path) -> Path:
 def discover_slugs(repo_root: Path) -> list[str]:
     rmds = sorted((repo_root / "vignettes").glob("*.Rmd"))
     return [path.stem for path in rmds]
+
+
+def description_hard_dependencies(path: Path) -> set[str]:
+    fields: dict[str, list[str]] = {}
+    current = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line[:1].isspace() and current:
+            fields[current].append(line.strip())
+            continue
+        if ":" not in line:
+            current = ""
+            continue
+        current, value = line.split(":", 1)
+        fields[current] = [value.strip()]
+
+    packages: set[str] = set()
+    for field in ("Depends", "Imports", "LinkingTo"):
+        for entry in ",".join(fields.get(field, [])).split(","):
+            match = re.match(r"\s*([A-Za-z][A-Za-z0-9.]*)", entry)
+            if match and match.group(1) != "R":
+                packages.add(match.group(1))
+    return packages
+
+
+def referenced_r_packages(repo_root: Path, code: str) -> set[str]:
+    try:
+        result = subprocess.run(
+            ["Rscript", "--vanilla", "-e", R_PACKAGE_REFERENCE_SCRIPT],
+            cwd=repo_root,
+            input=code,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise SystemExit("Rscript is required to detect Colab dependencies") from error
+    if result.returncode != 0:
+        raise SystemExit(f"Could not parse vignette R code:\n{result.stderr}")
+    return set(result.stdout.split())
+
+
+def colab_packages(repo_root: Path, cells: list[dict]) -> tuple[str, ...]:
+    code = "\n".join(
+        cell["source"] for cell in cells if cell["cell_type"] == "code"
+    )
+    referenced = referenced_r_packages(repo_root, code)
+    available = (
+        BASE_R_PACKAGES
+        | description_hard_dependencies(repo_root / "DESCRIPTION")
+        | set(COMMON_COLAB_PACKAGES)
+        | {"bifrost"}
+    )
+    optional = sorted(referenced - available)
+    return COMMON_COLAB_PACKAGES + tuple(optional)
 
 
 def markdown_cell(source: str) -> dict:
@@ -184,8 +283,7 @@ def rewrite_markdown_links(markdown: str) -> str:
     )
 
 
-def setup_source(slug: str) -> str:
-    packages = COMMON_COLAB_PACKAGES + COLAB_PACKAGES_BY_SLUG.get(slug, ())
+def setup_source(packages: tuple[str, ...]) -> str:
     package_vector = ", ".join(json.dumps(package) for package in packages)
     return f"""message("Detected logical CPUs: ", parallel::detectCores(logical = TRUE))
 if (!dir.exists("/content/bifrost")) {{
@@ -218,7 +316,6 @@ def convert(slug: str, repo_root: Path) -> dict:
             f"Converted from [`vignettes/{slug}.Rmd`]({REPO}/blob/main/vignettes/{slug}.Rmd).\n\n"
             f"{RUNTIME_NOTE}"
         ),
-        code_cell(setup_source(slug)),
     ]
 
     for block_type, header, content in parse_chunks(body):
@@ -241,6 +338,8 @@ def convert(slug: str, repo_root: Path) -> dict:
 
         if content.strip():
             cells.append(code_cell(content.strip() + "\n"))
+
+    cells.insert(1, code_cell(setup_source(colab_packages(repo_root, cells))))
 
     return {
         "cells": cells,

--- a/tools/colab_dependencies.py
+++ b/tools/colab_dependencies.py
@@ -1,0 +1,100 @@
+"""Detect R package dependencies used by executable Colab cells."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+BASE_R_PACKAGES = frozenset(
+    {
+        "base",
+        "compiler",
+        "datasets",
+        "graphics",
+        "grDevices",
+        "grid",
+        "methods",
+        "parallel",
+        "splines",
+        "stats",
+        "stats4",
+        "tcltk",
+        "tools",
+        "utils",
+    }
+)
+COMMON_COLAB_PACKAGES = ("remotes", "knitr")
+
+R_PACKAGE_REFERENCE_SCRIPT = r"""
+code <- paste(readLines(file("stdin"), warn = FALSE), collapse = "\n")
+expressions <- parse(text = code)
+packages <- character()
+
+walk <- function(node) {
+  if (is.call(node)) {
+    operator <- node[[1L]]
+    if (is.symbol(operator)) {
+      operator_name <- as.character(operator)
+      if (operator_name %in% c("::", ":::") && length(node) >= 3L) {
+        packages <<- c(packages, as.character(node[[2L]]))
+      }
+      if (operator_name %in% c("library", "require") &&
+          length(node) >= 2L &&
+          (is.symbol(node[[2L]]) || is.character(node[[2L]]))) {
+        packages <<- c(packages, as.character(node[[2L]]))
+      }
+      if (operator_name %in% c("requireNamespace", "loadNamespace") &&
+          length(node) >= 2L && is.character(node[[2L]])) {
+        packages <<- c(packages, as.character(node[[2L]]))
+      }
+    }
+    invisible(lapply(as.list(node), walk))
+  } else if (is.expression(node) || is.pairlist(node)) {
+    invisible(lapply(as.list(node), walk))
+  }
+}
+
+walk(expressions)
+cat(sort(unique(packages)), sep = "\n")
+"""
+
+
+def description_hard_dependencies(path: Path) -> set[str]:
+    fields: dict[str, list[str]] = {}
+    current = ""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line[:1].isspace() and current:
+            fields[current].append(line.strip())
+            continue
+        if ":" not in line:
+            current = ""
+            continue
+        current, value = line.split(":", 1)
+        fields[current] = [value.strip()]
+
+    packages: set[str] = set()
+    for field in ("Depends", "Imports", "LinkingTo"):
+        for entry in ",".join(fields.get(field, [])).split(","):
+            match = re.match(r"\s*([A-Za-z][A-Za-z0-9.]*)", entry)
+            if match and match.group(1) != "R":
+                packages.add(match.group(1))
+    return packages
+
+
+def referenced_r_packages(repo_root: Path, code: str) -> set[str]:
+    try:
+        result = subprocess.run(
+            ["Rscript", "--vanilla", "-e", R_PACKAGE_REFERENCE_SCRIPT],
+            cwd=repo_root,
+            input=code,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as error:
+        raise SystemExit("Rscript is required to detect Colab dependencies") from error
+    if result.returncode != 0:
+        raise SystemExit(f"Could not parse vignette R code:\n{result.stderr}")
+    return set(result.stdout.split())

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -28,6 +28,7 @@ BASE_R_PACKAGES = {
     "tools",
     "utils",
 }
+COMMON_COLAB_PACKAGES = {"remotes", "knitr"}
 
 R_PACKAGE_REFERENCE_SCRIPT = r"""
 code <- paste(readLines(file("stdin"), warn = FALSE), collapse = "\n")
@@ -42,9 +43,13 @@ walk <- function(node) {
       if (operator_name %in% c("::", ":::") && length(node) >= 3L) {
         packages <<- c(packages, as.character(node[[2L]]))
       }
-      if (operator_name %in% c("library", "require", "requireNamespace") &&
+      if (operator_name %in% c("library", "require") &&
           length(node) >= 2L &&
           (is.symbol(node[[2L]]) || is.character(node[[2L]]))) {
+        packages <<- c(packages, as.character(node[[2L]]))
+      }
+      if (operator_name %in% c("requireNamespace", "loadNamespace") &&
+          length(node) >= 2L && is.character(node[[2L]])) {
         packages <<- c(packages, as.character(node[[2L]]))
       }
     }
@@ -109,6 +114,7 @@ def referenced_r_packages(repo: Path, code: str) -> set[str]:
     result = run(
         repo,
         "Rscript",
+        "--vanilla",
         "-e",
         R_PACKAGE_REFERENCE_SCRIPT,
         input_text=code,
@@ -267,9 +273,16 @@ def main() -> None:
             "```\n\n"
             "```{r visible, eval=FALSE}\n"
             "visible_probe <- TRUE\n"
+            "library(autoLibrary)\n"
+            'requireNamespace("autoRequired", quietly = TRUE)\n'
+            'loadNamespace("autoLoaded")\n'
+            "autoNamespace::run()\n"
+            "ape::Ntip(NULL)\n"
+            "stats::lm(visible_probe ~ 1)\n"
             "```\n\n"
             "```{r hidden, include=FALSE, eval=FALSE}\n"
             "hidden_probe <- TRUE\n"
+            "hiddenPackage::run()\n"
             "```\n"
         )
         run(
@@ -291,6 +304,23 @@ def main() -> None:
             raise AssertionError("visible eval=FALSE chunks must be executable in Colab")
         if "hidden_probe <- TRUE" in policy_code:
             raise AssertionError("hidden unevaluated chunks must be omitted from Colab")
+        policy_setup_packages = bootstrapped_packages(
+            policy_notebook["cells"][1]["source"]
+        )
+        expected_policy_packages = {
+            "remotes",
+            "knitr",
+            "autoLibrary",
+            "autoLoaded",
+            "autoNamespace",
+            "autoRequired",
+        }
+        if policy_setup_packages != expected_policy_packages:
+            raise AssertionError(
+                "automatic dependency probe expected "
+                f"{sorted(expected_policy_packages)}, got "
+                f"{sorted(policy_setup_packages)}"
+            )
 
     theoretical_rmd = (
         source / "vignettes/theoretical-background-vignette.Rmd"
@@ -355,19 +385,29 @@ def main() -> None:
                 f"{notebook_path.name} setup must install the shared knitr dependency"
             )
 
-        expects_phylolm = (
-            notebook_path.stem == "pca-model-selection-and-bifrost-vignette"
+        body_code = "\n".join(
+            cell["source"]
+            for cell in notebook["cells"][2:]
+            if cell["cell_type"] == "code"
         )
-        if ('"phylolm"' in setup) != expects_phylolm:
+        expected_optional = referenced_r_packages(source, body_code) - (
+            BASE_R_PACKAGES
+            | hard_dependencies
+            | COMMON_COLAB_PACKAGES
+            | {"bifrost"}
+        )
+        actual_optional = bootstrapped_packages(setup) - COMMON_COLAB_PACKAGES
+        if actual_optional != expected_optional:
             raise AssertionError(
-                f"{notebook_path.name} setup has the wrong vignette-specific dependencies"
+                f"{notebook_path.name} expected automatic optional dependencies "
+                f"{sorted(expected_optional)}, got {sorted(actual_optional)}"
             )
         missing = missing_notebook_dependencies(source, notebook, hard_dependencies)
         if missing:
             raise AssertionError(
                 f"{notebook_path.name} executable cells use packages unavailable in "
-                f"Colab setup: {', '.join(sorted(missing))}. Add them to "
-                "COLAB_PACKAGES_BY_SLUG."
+                f"Colab setup: {', '.join(sorted(missing))}. Automatic dependency "
+                "detection did not add them to the setup cell."
             )
 
     if dependency_probe is None:

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -11,57 +11,12 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-
-BASE_R_PACKAGES = {
-    "base",
-    "compiler",
-    "datasets",
-    "graphics",
-    "grDevices",
-    "grid",
-    "methods",
-    "parallel",
-    "splines",
-    "stats",
-    "stats4",
-    "tcltk",
-    "tools",
-    "utils",
-}
-COMMON_COLAB_PACKAGES = {"remotes", "knitr"}
-
-R_PACKAGE_REFERENCE_SCRIPT = r"""
-code <- paste(readLines(file("stdin"), warn = FALSE), collapse = "\n")
-expressions <- parse(text = code)
-packages <- character()
-
-walk <- function(node) {
-  if (is.call(node)) {
-    operator <- node[[1L]]
-    if (is.symbol(operator)) {
-      operator_name <- as.character(operator)
-      if (operator_name %in% c("::", ":::") && length(node) >= 3L) {
-        packages <<- c(packages, as.character(node[[2L]]))
-      }
-      if (operator_name %in% c("library", "require") &&
-          length(node) >= 2L &&
-          (is.symbol(node[[2L]]) || is.character(node[[2L]]))) {
-        packages <<- c(packages, as.character(node[[2L]]))
-      }
-      if (operator_name %in% c("requireNamespace", "loadNamespace") &&
-          length(node) >= 2L && is.character(node[[2L]])) {
-        packages <<- c(packages, as.character(node[[2L]]))
-      }
-    }
-    invisible(lapply(as.list(node), walk))
-  } else if (is.expression(node) || is.pairlist(node)) {
-    invisible(lapply(as.list(node), walk))
-  }
-}
-
-walk(expressions)
-cat(sort(unique(packages)), sep = "\n")
-"""
+from colab_dependencies import (
+    BASE_R_PACKAGES,
+    COMMON_COLAB_PACKAGES,
+    description_hard_dependencies,
+    referenced_r_packages,
+)
 
 
 def run(
@@ -69,7 +24,6 @@ def run(
     *args: str,
     check: bool = True,
     env: dict[str, str] | None = None,
-    input_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         args,
@@ -78,7 +32,6 @@ def run(
         text=True,
         capture_output=True,
         env=env,
-        input=input_text,
     )
     if check and result.returncode != 0:
         raise AssertionError(
@@ -86,40 +39,6 @@ def run(
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
     return result
-
-
-def description_hard_dependencies(path: Path) -> set[str]:
-    fields: dict[str, list[str]] = {}
-    current = ""
-    for line in path.read_text().splitlines():
-        if line[:1].isspace() and current:
-            fields[current].append(line.strip())
-            continue
-        if ":" not in line:
-            current = ""
-            continue
-        current, value = line.split(":", 1)
-        fields[current] = [value.strip()]
-
-    packages: set[str] = set()
-    for field in ("Depends", "Imports", "LinkingTo"):
-        for entry in ",".join(fields.get(field, [])).split(","):
-            match = re.match(r"\s*([A-Za-z][A-Za-z0-9.]*)", entry)
-            if match and match.group(1) != "R":
-                packages.add(match.group(1))
-    return packages
-
-
-def referenced_r_packages(repo: Path, code: str) -> set[str]:
-    result = run(
-        repo,
-        "Rscript",
-        "--vanilla",
-        "-e",
-        R_PACKAGE_REFERENCE_SCRIPT,
-        input_text=code,
-    )
-    return set(result.stdout.split())
 
 
 def bootstrapped_packages(setup: str) -> set[str]:
@@ -201,6 +120,7 @@ def make_fixture(source: Path, destination: Path) -> None:
     tools.mkdir()
     for filename in [
         "build-colab-notebook.py",
+        "colab_dependencies.py",
         "render-vignette-pdf.R",
         "test-vignette-artifacts.py",
         "vignette_artifacts.R",
@@ -263,6 +183,10 @@ def main() -> None:
         shutil.copy2(
             source / "tools/build-colab-notebook.py",
             repo / "tools/build-colab-notebook.py",
+        )
+        shutil.copy2(
+            source / "tools/colab_dependencies.py",
+            repo / "tools/colab_dependencies.py",
         )
         (repo / "vignettes/colab-policy-probe.Rmd").write_text(
             "---\n"
@@ -393,10 +317,10 @@ def main() -> None:
         expected_optional = referenced_r_packages(source, body_code) - (
             BASE_R_PACKAGES
             | hard_dependencies
-            | COMMON_COLAB_PACKAGES
+            | set(COMMON_COLAB_PACKAGES)
             | {"bifrost"}
         )
-        actual_optional = bootstrapped_packages(setup) - COMMON_COLAB_PACKAGES
+        actual_optional = bootstrapped_packages(setup) - set(COMMON_COLAB_PACKAGES)
         if actual_optional != expected_optional:
             raise AssertionError(
                 f"{notebook_path.name} expected automatic optional dependencies "
@@ -597,6 +521,8 @@ def main() -> None:
             raise AssertionError(f"PDF cache key is missing {pattern}")
     if "'.github/workflows/pkgdown.yml'" not in workflow:
         raise AssertionError("PDF cache key must include its production workflow")
+    if "'tools/colab_dependencies.py'" not in workflow:
+        raise AssertionError("PDF cache key must include Colab dependency detection")
 
     renderer = (source / "tools/render-vignette-pdf.R").read_text()
     if "rmarkdown::resolve_output_format(" not in renderer:
@@ -619,6 +545,8 @@ def main() -> None:
     artifact_tool = (source / "tools/vignette_artifacts.R").read_text()
     if '"MISSING"' not in artifact_tool:
         raise AssertionError("artifact hashes must mark missing dependency paths")
+    if '"tools/colab_dependencies.py"' not in artifact_tool:
+        raise AssertionError("artifact hashes must include Colab dependency detection")
 
     pr_workflow = (source / ".github/workflows/vignette-artifacts.yml").read_text()
     if "\npermissions:\n  contents: write\n" in pr_workflow:
@@ -631,6 +559,8 @@ def main() -> None:
         raise AssertionError("PR artifact checks must pin checkout to the event SHA")
     if "ref: ${{ github.event.pull_request.head.ref }}" in pr_workflow:
         raise AssertionError("PR artifact checks must not checkout a mutable branch ref")
+    if "      - tools/colab_dependencies.py" not in pr_workflow:
+        raise AssertionError("PR artifact workflow must watch Colab dependency detection")
     generate_step_name = "      - name: Generate changed Colab notebooks"
     audit_step_name = "      - name: Test vignette artifacts"
     generate_step = pr_workflow.find(generate_step_name)

--- a/tools/vignette_artifacts.R
+++ b/tools/vignette_artifacts.R
@@ -162,6 +162,7 @@ shared_dependencies <- function() {
     "tools/vignette_artifacts.R",
     "tools/render-vignette-pdf.R",
     "tools/build-colab-notebook.py",
+    "tools/colab_dependencies.py",
     "tools/test-vignette-artifacts.py",
     repo_rel(list_repo_files("R")),
     repo_rel(list_repo_files("inst/extdata"))


### PR DESCRIPTION
## Summary

- remove the manually maintained per-vignette Colab dependency map
- parse each notebook's executable R cells for package loads and namespace calls
- subtract base R and hard `DESCRIPTION` dependencies, then inject optional packages into the setup cell
- retain exact dependency auditing as a CI backstop

## Verification

- `python3 tools/test-vignette-artifacts.py`
- `python3 -m py_compile tools/build-colab-notebook.py tools/test-vignette-artifacts.py`
- deterministic regeneration of all current notebooks
- synthetic unknown-package conversion probe
- temporary conversion of all `berv_et_al_2026` skeleton and simulation vignettes