### PR TITLE
Separate development NEWS from 0.1.4 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bifrost
 Title: Branch-Level Inference Framework for Recognizing Optimal Shifts in Traits
-Version: 0.1.4
+Version: 0.1.4.9000
 Authors@R: c(
     person(given = c("Jacob", "S."), family = "Berv", email = "jacob.berv@gmail.com", role = c("aut", "cre", "cph", "fnd"), comment = c(ORCID = "0000-0002-5962-0621")),
     person(given = "Nathan", family = "Fox", role = "aut", comment = c(ORCID = "0000-0002-2816-9751")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# bifrost 0.1.4
+# bifrost (development version)
 
 * Search progress:
   - `searchOptimalConfiguration()` now displays persistent, Future-compatible CLI progress for candidate scoring, greedy shift evaluation, and IC-weight re-estimation by default.
@@ -6,6 +6,24 @@
   - Stage spinners now redraw continuously during long model fits while completion counts, percentages, and ETA advance only after a fit finishes.
   - Added `progress = FALSE` as an explicit opt-out independent of detailed `verbose` messages.
   - Captured expression-valued search inputs now print safely in `print.bifrost_search()` output.
+
+* Search inputs and diagnostics:
+  - Formula-based searches now accept formula objects as well as character strings, numeric response-only data frames for intercept-only searches, and named-column data-frame formulas for pGLS-style workflows.
+  - Added `icTrajectory()` and its `plot()` method for inspecting stored search histories; `plot_ic_acceptance_matrix()` remains available as a compatibility wrapper.
+  - Stored model-fit histories now retain richer accepted, rejected, and errored candidate records.
+
+* Branch-rate summaries:
+  - Added the `rateMap()` workflow and supporting view, control, flagging, print, and plot methods for summarizing branch-rate patterns across completed searches.
+  - Improved category legends for uneven rate breaks and strengthened validation of category colors.
+
+* Documentation / vignettes:
+  - Added two rate-map jaw-shape workflows and refreshed the existing jaw-shape vignette.
+  - Added tooling and CI workflows for generated vignette PDFs and executable Colab notebooks.
+
+* Maintenance:
+  - Added an automated CRAN downloads tracker and generated chart for the README and development website.
+
+# bifrost 0.1.4
 
 * Documentation / vignettes:
   - Added a new "Quick Start with bifrost" vignette with a minimal end-to-end simulated example.


### PR DESCRIPTION
## Summary

- bump the source package version from `0.1.4` to `0.1.4.9000`
- preserve the released `0.1.4` changelog exactly as shipped to CRAN
- add a separate development section describing user-facing changes on `main` since `v0.1.4`

## Why

Post-release search-progress changes had been added under the `0.1.4` heading, making the repository changelog imply that they were part of the CRAN release. The source package also still reported the same version as CRAN despite containing unreleased changes.

## Impact

The CRAN release history is now accurate, while GitHub installations are clearly identified as a development version. Future unreleased changes have a dedicated NEWS section until the next release version is chosen.

## Validation

- full `devtools::test()` suite
- `R CMD build --no-build-vignettes --no-manual`
- verified the released `0.1.4` NEWS section matches the `v0.1.4` tag exactly
- verified the development entries against `main`, excluding feature-branch-only work