### PR TITLE
docs: align homepage and development news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,19 +16,33 @@
   - Added the `rateMap()` workflow and supporting view, control, flagging, print, and plot methods for summarizing branch-rate patterns across completed searches.
   - Improved category legends for uneven rate breaks and strengthened validation of category colors.
 
-* Empirically calibrated simulations:
-  - Added empirical null, proportional-shift, and integration-rate robustness workflows centered on the fitted residual covariance.
-  - Added `simulation_generator = c("original", "empirical")` for explicit generator selection.
+* Lineage-rate and shift-distribution analyses:
+  - Added `lineage_rates()` for tip-level summaries of inherited rate histories and associated branch and shift diagnostics.
+  - Added tools for extracting shift nodes, transitions, waiting times, and magnitude groups; fitting waiting-time and lineage-rate distributions; bootstrapping rate-distribution summaries; and comparing shift magnitudes.
+
+* Regime covariance and integration analyses:
+  - Added `fit_regime_covariances()`, `fit_regime_covariance_runs()`, and their summary helpers for post-hoc covariance estimation across fitted regimes and search runs.
+  - Added module diagnostics, correlation-matrix PCA, integration-relationship summaries, and `regime_integration_pgls()` for examining regime-specific covariance structure and downstream relationships.
+
+* Simulation studies and tuning:
+  - Added reproducible simulation templates, null and shifted dataset generators, false-positive and shift-recovery studies, recovery evaluation, and fixed-IC tuning grids.
+  - Added empirical null, proportional-shift, and integration-rate robustness workflows centered on fitted residual covariance, with `simulation_generator = c("original", "empirical")` for explicit generator selection.
   - Simulation generators now default to `"original"` for exact reproduction of the published operations; the full-covariance Wishart/spectral generator remains available explicitly as `simulation_generator = "empirical"`.
+  - `selectTunedSearchParameters()` filters settings using null false-positive and evaluability safeguards, then ranks feasible settings by fuzzy balanced accuracy by default.
   - Reduced multisession transfer size by using compact namespace-level workers and by avoiding a complete calibration template inside every replicate's call record.
 
 * Documentation / vignettes:
   - Added two rate-map jaw-shape workflows and refreshed the existing jaw-shape vignette.
+  - Added a five-part avian skeleton case study covering search inspection, lineage rates, shift distributions, magnitude comparisons, and post-hoc covariance and integration analyses.
   - Added a two-part empirically calibrated simulation guide covering performance assessment, search tuning, and empirical application.
   - Added tooling and CI workflows for generated vignette PDFs and executable Colab notebooks.
+  - Standardized code annotations, figure captions, rendered widget layout, and AI-assistance disclosures across the website articles.
   - Updated Berv et al. (2026) citation metadata and avian skeleton references for the published *Nature Ecology & Evolution* article DOI.
 
 * Maintenance:
+  - Increased the minimum supported R version from 4.1 to 4.2.
+  - Hardened lineage-rate, regime-integration, simulation, and tuning workflows around malformed inputs, failed fits, reproducible parallel execution, and infeasible selections.
+  - Expanded CI coverage for package checks, exact coverage accounting, parallel smoke tests, serialized empirical artifacts, and generated vignette outputs.
   - Added an automated CRAN downloads tracker and generated chart for the README and development website.
 
 # bifrost 0.1.4

--- a/README.md
+++ b/README.md
@@ -66,11 +66,15 @@ CRAN currently provides `bifrost` 0.1.4. The GitHub development version includes
 - Search histories can now be inspected with the `icTrajectory()` extractor and plotted directly with `plot()`, for example `traj <- icTrajectory(search); plot(traj)`. The older `plot_ic_acceptance_matrix()` helper remains available as a compatibility wrapper.
 - Stored model-fit histories now include richer per-candidate records, including errored candidate fits, so search diagnostics can preserve accepted, rejected, and errored proposals.
 - The `rateMap()` workflow, along with `rateMapView()`, `rateMapControl()`, `rateMapRateFlags()`, and `plot()` / `print()` methods for `rateMap` objects, summarizes and visualizes branch-rate patterns from completed `bifrost` searches. The two rate-map jaw-shape articles below are part of this development-version documentation.
+- `lineage_rates()` and the shift-distribution toolkit summarize inherited lineage rates, shift timing and waiting times, rate-distribution fits, and shift-magnitude patterns from completed searches.
+- Regime covariance and integration tools fit and summarize per-regime covariance structure, diagnose modules and correlation-space variation, compare integration relationships, and support post-hoc pGLS analyses.
+- The simulation framework creates reproducible null and shifted datasets, evaluates strict and fuzzy shift recovery, runs fixed-IC tuning grids, and selects search settings using fuzzy balanced accuracy by default. The original manuscript generator remains the default, with the empirically calibrated full-covariance generator available explicitly.
 - Formula-based searches now accept formula objects as well as character strings, support numeric response-only data frames for intercept-only searches, and support named-column data-frame formulas such as `cbind(y1, y2) ~ size + grp` for pGLS-style workflows.
+- The development version requires R 4.2 or newer.
 
 Some repository workflows are still being actively developed, especially methodological guidance for pGLS-style uses of `bifrost` with hidden branch-specific rate variation. Repository tooling and generated site assets, such as the CRAN downloads tracker, support development and documentation rather than the core CRAN API.
 
-Long empirical article sequences, including the avian skeleton workflow on the pkgdown site, are intentionally excluded from the CRAN package tarball to avoid rebuilding large manuscript-scale demonstrations during CRAN checks.
+All source vignettes listed below are maintained as website articles and excluded from the CRAN package tarball. This avoids rebuilding manuscript-scale demonstrations, including the five-part avian skeleton workflow, during CRAN checks while keeping the complete documentation available through pkgdown.
 
 ## Overview
 
@@ -96,16 +100,39 @@ Long empirical article sequences, including the avian skeleton workflow on the p
 - [Whole-Tree Models, PCA, and bifrost](https://jakeberv.com/bifrost/articles/pca-model-selection-and-bifrost-vignette.html)  
   Explains why whole-tree homogeneous models and PCA truncation can mislead inference when evolutionary processes vary across the tree.
 
-### Using bifrost
+### Getting Started
 
 - [Quick Start with bifrost](https://jakeberv.com/bifrost/articles/quick-start-vignette.html)  
   A practical introduction to the core `bifrost` workflow using a minimal simulated example, including setup, key arguments, outputs, and interpretation.
 - [Detecting Evolutionary Shifts in Paleozoic Fish Jaw Shape with bifrost](https://jakeberv.com/bifrost/articles/jaw-shape-vignette.html)  
   A full empirical case study using the packaged fossil jaw-shape dataset, showing how to run, inspect, and interpret a real `bifrost` analysis end to end.
+
+### Rate Mapping
+
 - [Mapping Sensitivity in Jaw-Shape Evolutionary Rates with rateMap, Part 1](https://jakeberv.com/bifrost/articles/rate-map-jaw-shape-vignette.html)
   A follow-up case study showing the compute-first `rateMap()` workflow: build a reusable branch-rate summary object from completed searches, diagnose broad fitted-rate ranges, and display near-zero branches with explicit diagnostic metadata.
 - [Mapping Sensitivity in Jaw-Shape Evolutionary Rates with rateMap, Part 2](https://jakeberv.com/bifrost/articles/rate-map-jaw-shape-part-2-comparisons.html)
   Extends the same jaw-shape sweep into IC weighting, uncertainty summaries, same-topology tree samples, original-scale rates, interval maps, and additional diagnostics.
+
+### Avian Skeleton Case Study
+
+- [Passerine Body Plan Evolution, Part 1: Fitting and Inspecting a Search](https://jakeberv.com/bifrost/articles/avian-skeleton-part-1.html)
+  Introduces the empirical dataset, fits the manuscript-scale search, and inspects the inferred shifts and IC trajectory.
+- [Passerine Body Plan Evolution, Part 2: Lineage-Rate Summaries](https://jakeberv.com/bifrost/articles/avian-skeleton-part-2.html)
+  Reconstructs tip-level lineage-rate summaries and visualizes their temporal and spatial variation.
+- [Passerine Body Plan Evolution, Part 3: Shift Timing and Distribution Fits](https://jakeberv.com/bifrost/articles/avian-skeleton-part-3.html)
+  Extracts shift events and evaluates waiting-time and lineage-rate distributions.
+- [Passerine Body Plan Evolution, Part 4: Shift Magnitude Comparisons](https://jakeberv.com/bifrost/articles/avian-skeleton-part-4.html)
+  Quantifies and compares the magnitudes of inferred rate shifts among biological groups.
+- [Passerine Body Plan Evolution, Part 5: Post-hoc Integration and Covariance Structure](https://jakeberv.com/bifrost/articles/avian-skeleton-part-5.html)
+  Examines regime-specific covariance, modularity, integration, and post-hoc phylogenetic relationships.
+
+### Simulation and Calibration
+
+- [Empirically Calibrated Simulations for bifrost, Part 1: Performance](https://jakeberv.com/bifrost/articles/simulation-study-part-1.html)
+  Builds reproducible null and shifted simulations and reports false-positive behavior and strict and fuzzy shift recovery.
+- [Empirically Calibrated Simulations for bifrost, Part 2: Tuning and Application](https://jakeberv.com/bifrost/articles/simulation-study-part-2.html)
+  Tunes search controls with null safeguards and fuzzy balanced accuracy, then carries the selected settings into empirical analysis.
 
 ## Additional note
 


### PR DESCRIPTION
## Summary

- align the README development-version overview with the APIs merged across the split PR stack
- mirror all 13 pkgdown articles under the five configured navigation groups
- complete the development NEWS with lineage-rate, shift-distribution, regime-integration, simulation, tuning, documentation, CI, and R-version changes
- clarify that all source vignettes are maintained as website articles and excluded from the CRAN tarball

## Impact

This is a documentation-only change. It makes the repository README, pkgdown homepage, and development changelog describe the same public surface and article organization.

## Validation

- `Rscript -e "pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)"`
- pkgdown metadata checks reported URLs, favicons, Open Graph, article metadata, and reference metadata as OK
- verified all 13 `_pkgdown.yml` article slugs have rendered HTML files and homepage links
- verified the new development sections appear in the rendered NEWS page
- `git diff --check`