### PR TITLE
ci: migrate workflows to Node 24 actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -88,7 +88,7 @@ jobs:
       #   run: Rscript -e 'dir.create("doc", showWarnings = FALSE); devtools::build_vignettes()'
       #
       # - name: Upload vignette artifacts
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@v6
       #   with:
       #     name: built-vignettes-${{ matrix.config.os }}-${{ matrix.config.r }}
       #     path: doc/

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Restore cached vignette PDFs
         id: vignette-pdf-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .cache/vignette-artifacts
           key: vignette-pdfs-${{ runner.os }}-${{ hashFiles('vignettes/**/*.Rmd', 'vignettes/**/*.png', 'vignettes/**/*.gif', 'vignettes/**/*.jpg', 'vignettes/**/*.jpeg', 'vignettes/**/*.svg', 'vignettes/**/*.csv', 'vignettes/**/*.txt', 'vignettes/**/*.rds', 'vignettes/**/*.RDS', 'vignettes/**/*.R', 'R/**', 'inst/extdata/**', 'DESCRIPTION', '_pkgdown.yml', '.github/workflows/pkgdown.yml', 'tools/vignette_artifacts.R', 'tools/render-vignette-pdf.R', 'tools/build-colab-notebook.py', 'tools/colab_dependencies.py', 'tools/test-vignette-artifacts.py') }}
@@ -84,16 +84,17 @@ jobs:
 
       - name: Save vignette PDF cache
         if: steps.vignette-pdf-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .cache/vignette-artifacts
           key: ${{ steps.vignette-pdf-cache.outputs.cache-primary-key }}
 
       - name: Upload site artifact for Pages
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
+          include-hidden-files: true
 
   deploy:
     if: github.event_name != 'pull_request'
@@ -109,4 +110,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -22,7 +22,7 @@ jobs:
       NOT_CRAN: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -51,7 +51,7 @@ jobs:
       NOT_CRAN: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -78,7 +78,7 @@ jobs:
           }
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         if: always()
         with:
           # Fail if error if not on PR, or if on PR and token is given
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/update-cran-downloads.yml
+++ b/.github/workflows/update-cran-downloads.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare persistent update branch
         shell: bash
@@ -33,9 +33,10 @@ jobs:
           git checkout -B "$UPDATE_BRANCH" "origin/$BASE_BRANCH"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Setup pnpm
         run: |

--- a/.github/workflows/vignette-artifacts.yml
+++ b/.github/workflows/vignette-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
       colab_slugs: ${{ steps.changed.outputs.colab_slugs }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload generated Colab notebooks
         if: steps.changed.outputs.colab_slugs != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: colab-notebooks-${{ github.event.pull_request.head.sha }}
           path: vignettes/colab/*.ipynb
@@ -134,14 +134,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Download generated Colab notebooks
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: colab-notebooks-${{ github.event.pull_request.head.sha }}
           path: vignettes/colab

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -921,7 +921,7 @@ def main() -> None:
             + ", ".join(late_or_missing_reports)
         )
     codecov_step = (
-        "      - uses: codecov/codecov-action@v5\n"
+        "      - uses: codecov/codecov-action@v6\n"
         "        if: always()\n"
     )
     if codecov_step not in coverage_workflow:


### PR DESCRIPTION
## Summary

- replace direct Node 20 action pins with the first conservative Node 24-compatible majors
- update checkout, cache, setup-node, artifact upload/download, Pages upload/deploy, and Codecov actions
- preserve `docs/.nojekyll` by explicitly including hidden files in the Pages artifact
- preserve CRAN-download automation behavior by explicitly disabling setup-node automatic package-manager caching

## Root cause

GitHub hosted runners now annotate actions that target Node 20 and force them onto Node 24. The warnings affected the R package checks, coverage, pkgdown, vignette-artifact, and CRAN-download workflows.

## Impact

This changes CI action runtimes only. It does not change bifrost package code, package contents, vignettes, tests, or analysis behavior.

## Validation

- confirmed the legacy action-pin policy check fails before the edits and passes afterward
- parsed all five modified workflows as YAML
- ran actionlint v1.7.12 successfully, suppressing only the pre-existing inactive `matrix.config.http-user-agent` finding
- verified each selected official action manifest declares Node 24
- verified Codecov v6 uses github-script v8 and Pages upload v5 uses upload-artifact v7
- verified `include-hidden-files: true` and `package-manager-cache: false` are present
- `git diff --check`