### PR TITLE
docs: add development status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,22 +59,14 @@ Install [Rtools](https://cran.r-project.org/bin/windows/Rtools/) for your R vers
 **macOS users:**  
 You may need to install [XQuartz](https://www.xquartz.org/) to build or run packages that depend on certain graphical or system libraries.
 
-## Release status
+## Development status
 
-CRAN currently provides `bifrost` 0.1.4. The GitHub development version includes repository-only additions documented here but not yet available from CRAN:
-
-- Search histories can now be inspected with the `icTrajectory()` extractor and plotted directly with `plot()`, for example `traj <- icTrajectory(search); plot(traj)`. The older `plot_ic_acceptance_matrix()` helper remains available as a compatibility wrapper.
-- Stored model-fit histories now include richer per-candidate records, including errored candidate fits, so search diagnostics can preserve accepted, rejected, and errored proposals.
-- The `rateMap()` workflow, along with `rateMapView()`, `rateMapControl()`, `rateMapRateFlags()`, and `plot()` / `print()` methods for `rateMap` objects, summarizes and visualizes branch-rate patterns from completed `bifrost` searches. The two rate-map jaw-shape articles below are part of this development-version documentation.
-- `lineage_rates()` and the shift-distribution toolkit summarize inherited lineage rates, shift timing and waiting times, rate-distribution fits, and shift-magnitude patterns from completed searches.
-- Regime covariance and integration tools fit and summarize per-regime covariance structure, diagnose modules and correlation-space variation, compare integration relationships, and support post-hoc pGLS analyses.
-- The simulation framework creates reproducible null and shifted datasets, evaluates strict and fuzzy shift recovery, runs fixed-IC tuning grids, and selects search settings using fuzzy balanced accuracy by default. The original manuscript generator remains the default, with the empirically calibrated full-covariance generator available explicitly.
-- Formula-based searches now accept formula objects as well as character strings, support numeric response-only data frames for intercept-only searches, and support named-column data-frame formulas such as `cbind(y1, y2) ~ size + grp` for pGLS-style workflows.
-- The development version requires R 4.2 or newer.
-
-Some repository workflows are still being actively developed, especially methodological guidance for pGLS-style uses of `bifrost` with hidden branch-specific rate variation. Repository tooling and generated site assets, such as the CRAN downloads tracker, support development and documentation rather than the core CRAN API.
-
-All source vignettes listed below are maintained as website articles and excluded from the CRAN package tarball. This avoids rebuilding manuscript-scale demonstrations, including the five-part avian skeleton workflow, during CRAN checks while keeping the complete documentation available through pkgdown.
+CRAN provides `bifrost` 0.1.4. The GitHub development version contains
+unreleased features and documentation and requires R 4.2 or newer. See the
+[development-status page](https://jakeberv.com/bifrost/articles/development-status.html)
+for a stable-versus-development comparison, current caveats, and the website
+article packaging policy; see [NEWS](https://jakeberv.com/bifrost/news/index.html)
+for the complete changelog.
 
 ## Overview
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,10 @@ url: https://jakeberv.com/bifrost/
 # Vignettes are tracked in this source checkout so pkgdown can build articles,
 # but .Rbuildignore excludes vignettes/ from the package tarball.
 articles:
+  - title: Project Status
+    desc: Release availability and development-version differences.
+    contents:
+      - articles/development-status
   - title: Background
     navbar: Background
     contents:
@@ -88,7 +92,9 @@ template:
             (nameCode && nameCode.textContent) ||
             window.location.pathname.split('/').pop() ||
             '';
-          let slug = sourceText.replace(/^.*\//, '');
+          const sourcePath = sourceText.replace(/\\/g, '/');
+          if (sourcePath.includes('/articles/')) return;
+          let slug = sourcePath.replace(/^.*\//, '');
           const lowerSlug = slug.toLowerCase();
           if (lowerSlug.endsWith('.rmd')) {
             slug = slug.slice(0, -4);

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -938,6 +938,10 @@ def main() -> None:
         raise AssertionError("unused pkgdown header include must not remain tracked")
     if "const encodedSlug = encodeURIComponent(slug);" not in pkgdown_config:
         raise AssertionError("pkgdown artifact links must URL-encode vignette slugs")
+    if "if (sourcePath.includes('/articles/')) return;" not in pkgdown_config:
+        raise AssertionError(
+            "pkgdown artifact links must skip website-only articles"
+        )
     if "pdf.href = './' + encodedSlug + '.pdf';" not in pkgdown_config:
         raise AssertionError("pkgdown PDF link must use the encoded vignette slug")
     if "encodedSlug + '.ipynb';" not in pkgdown_config:

--- a/vignettes/articles/development-status.Rmd
+++ b/vignettes/articles/development-status.Rmd
@@ -1,0 +1,74 @@
+---
+title: "Development Status"
+description: "How the GitHub development version differs from the current CRAN release."
+---
+
+`bifrost` is available as a stable CRAN package and as a GitHub development
+version. The development version is where completed features and documentation
+are assembled and tested before the next CRAN release.
+
+## At a glance
+
+| Distribution | Version | Installation | Best for |
+|---|---:|---|---|
+| [CRAN](https://CRAN.R-project.org/package=bifrost) | 0.1.4 | `install.packages("bifrost")` | Reproducible analyses using the current public release |
+| [GitHub](https://github.com/jakeberv/bifrost) | 0.1.4.9000 | `remotes::install_github("jakeberv/bifrost")` | Evaluating unreleased features and following the latest documentation |
+
+The GitHub development version requires R 4.2 or newer. Because it is
+unreleased, its interfaces and defaults may still change before the next CRAN
+release.
+
+## What the development version adds
+
+The development version currently extends the CRAN release in several related
+areas:
+
+- **Search inspection and diagnostics.** `icTrajectory()` and its `plot()`
+  method expose search histories, while richer stored candidate records retain
+  accepted, rejected, and errored fits.
+- **Branch-rate summaries.** `rateMap()` and its supporting view, control,
+  flagging, print, and plot methods summarize branch-rate patterns across
+  completed searches.
+- **Lineage rates and shift distributions.** `lineage_rates()` and related
+  tools summarize inherited lineage rates, shift timing and waiting times,
+  rate distributions, and shift magnitudes.
+- **Regime covariance and integration.** Post-hoc tools estimate and summarize
+  regime-specific covariance structure, diagnose modules and correlation-space
+  variation, compare integration relationships, and support pGLS analyses.
+- **Simulation and tuning.** Reproducible null and shifted simulations support
+  strict and fuzzy recovery assessment, fixed-IC tuning grids, null safeguards,
+  and tuning selection by fuzzy balanced accuracy.
+- **Formula-based searches.** Searches accept formula objects or character
+  strings, response-only numeric data frames for intercept-only analyses, and
+  named-column formulas such as `cbind(y1, y2) ~ size + grp`.
+- **Expanded worked documentation.** The website includes rate-mapping,
+  five-part avian skeleton, and two-part simulation and calibration workflows,
+  together with downloadable PDFs and executable Colab notebooks.
+
+The detailed, itemized record of these changes is maintained in
+[NEWS](../news/index.html).
+
+## Current caveats
+
+Some repository workflows and their methodological guidance remain under
+active development, especially pGLS-style uses of `bifrost` with hidden
+branch-specific rate variation. The simulation framework continues to use the
+original manuscript generator by default; the empirically calibrated
+full-covariance generator is available only when explicitly selected.
+
+Repository automation and generated site assets, including the CRAN downloads
+tracker, support package development and documentation but are not part of the
+core CRAN API.
+
+## Website articles and the package tarball
+
+The source files for the website articles are maintained in this repository but
+excluded from the CRAN source-package tarball. This keeps manuscript-scale
+demonstrations, including the five-part avian skeleton workflow, out of routine
+package installation and CRAN checks while preserving the complete rendered
+documentation on the pkgdown website.
+
+For stable release information, use the
+[CRAN package page](https://CRAN.R-project.org/package=bifrost). For unreleased
+changes, consult [NEWS](../news/index.html) and the
+[GitHub repository](https://github.com/jakeberv/bifrost).


### PR DESCRIPTION
## Summary

- replace the long README release-status inventory with a concise development-status notice and links
- add a curated, website-only Development Status page comparing the CRAN and GitHub versions
- list the page under Project Status in the pkgdown articles index
- prevent PDF and Colab controls from appearing on website-only articles, with a regression assertion

## Why

The detailed development inventory interrupted the README's installation-to-overview flow and substantially duplicated `NEWS.md`. The new page keeps the README concise while preserving a user-facing stable-versus-development comparison, current caveats, and the website article packaging policy.

## Validation

- full `testthat::test_local()` suite
- `python3 tools/test-vignette-artifacts.py`
- pkgdown renders of the homepage, Development Status article, articles index, NEWS page, and Quick Start article
- Playwright DOM checks confirming no artifact controls on the website-only page and unchanged PDF/Colab controls on Quick Start
- `R CMD build` source archive inspection confirming `vignettes/` and the status article remain excluded from the package tarball
