### PR TITLE
Render pkgdown formulas with KaTeX

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -36,6 +36,7 @@ articles:
       - simulation-study-part-2
 template:
   bootstrap: 5
+  math-rendering: katex
   includes:
     in_header: |
       <script data-goatcounter="https://bifrost.goatcounter.com/count"

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -932,6 +932,22 @@ def main() -> None:
         raise AssertionError("PDF renderer must resolve each vignette's YAML format")
 
     pkgdown_config = (source / "_pkgdown.yml").read_text()
+    math_renderer = run(
+        source,
+        "Rscript",
+        "--vanilla",
+        "-e",
+        (
+            'config <- yaml::read_yaml("_pkgdown.yml"); '
+            'value <- config$template[["math-rendering"]]; '
+            "if (!is.null(value)) cat(value)"
+        ),
+    ).stdout.strip()
+    if math_renderer != "katex":
+        raise AssertionError(
+            "pkgdown config must use KaTeX so equations render across reference "
+            "pages and articles"
+        )
     if "bifrost.goatcounter.com/count" not in pkgdown_config:
         raise AssertionError("pkgdown config must inline the GoatCounter header include")
     if (source / "pkgdown/extra-head.html").exists():

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -41,6 +41,27 @@ def run(
     return result
 
 
+def pkgdown_template_value(config_text: str, key: str) -> str | None:
+    in_template = False
+    key_pattern = re.compile(
+        rf"^  {re.escape(key)}:\s*(?P<value>[^#]*?)(?:\s+#.*)?$"
+    )
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        if not in_template:
+            if re.fullmatch(r"template:\s*(?:#.*)?", line):
+                in_template = True
+            continue
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not line[0].isspace():
+            break
+        match = key_pattern.fullmatch(line)
+        if match:
+            return match.group("value").strip().strip("\"'")
+    return None
+
+
 def bootstrapped_packages(setup: str) -> set[str]:
     match = re.search(r"colab_packages\s*<-\s*c\((.*?)\)", setup, re.DOTALL)
     if not match:
@@ -932,18 +953,28 @@ def main() -> None:
         raise AssertionError("PDF renderer must resolve each vignette's YAML format")
 
     pkgdown_config = (source / "_pkgdown.yml").read_text()
-    math_renderer = run(
-        source,
-        "Rscript",
-        "--vanilla",
-        "-e",
+    pkgdown_math_parser_cases = (
+        ("template:\n  math-rendering: katex\n", "katex"),
+        ("template:\n  math-rendering: 'katex' # renderer\n", "katex"),
+        ("template:\n  # math-rendering: katex\n", None),
         (
-            'config <- yaml::read_yaml("_pkgdown.yml"); '
-            'template <- config[["template"]]; '
-            'value <- if (is.list(template)) template[["math-rendering"]] else NULL; '
-            "if (!is.null(value)) cat(value)"
+            "template:\n"
+            "  includes:\n"
+            "    in_header: |\n"
+            "      math-rendering: katex\n"
+            "navbar:\n"
+            "  math-rendering: katex\n",
+            None,
         ),
-    ).stdout.strip()
+    )
+    for config_text, expected in pkgdown_math_parser_cases:
+        actual = pkgdown_template_value(config_text, "math-rendering")
+        if actual != expected:
+            raise AssertionError(
+                "pkgdown template parser returned "
+                f"{actual!r}; expected {expected!r}"
+            )
+    math_renderer = pkgdown_template_value(pkgdown_config, "math-rendering")
     if math_renderer != "katex":
         raise AssertionError(
             "pkgdown config must use KaTeX so equations render across reference "

--- a/tools/test-vignette-artifacts.py
+++ b/tools/test-vignette-artifacts.py
@@ -939,7 +939,8 @@ def main() -> None:
         "-e",
         (
             'config <- yaml::read_yaml("_pkgdown.yml"); '
-            'value <- config$template[["math-rendering"]]; '
+            'template <- config[["template"]]; '
+            'value <- if (is.list(template)) template[["math-rendering"]] else NULL; '
             "if (!is.null(value)) cat(value)"
         ),
     ).stdout.strip()


### PR DESCRIPTION
## Summary

- configure pkgdown to use KaTeX sitewide
- add a parsed-YAML regression guard for the math renderer
- verify every formula-bearing reference page and article

## Root cause

pkgdown reference pages emitted Rd `\eqn{}` and `\deqn{}` content as TeX delimiters, but the site used the default MathML mode and loaded no JavaScript renderer for those reference pages. As a result, formulas such as the lineage-rate equations appeared as literal TeX on the deployed site.

## Impact

Reference pages and articles now share an explicit KaTeX renderer. This fixes `lineage_rates()` and prevents the same failure on the other formula-bearing documentation pages.

## Validation

- red-green regression cycle for the missing renderer
- `python3 tools/test-vignette-artifacts.py`
- `git diff --check`
- full `pkgdown::build_site_github_pages()` build
- browser audit of all seven formula-bearing pages:
  - four reference topics
  - three articles
  - 107 rendered formulas
  - zero KaTeX errors
  - zero visible TeX delimiters
- independent read-only review with no Critical or Important findings
