### PR TITLE
Add Nature Ecology & Evolution paper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Codecov test coverage](https://codecov.io/gh/jakeberv/bifrost/graph/badge.svg)](https://app.codecov.io/gh/jakeberv/bifrost)
 [![CRAN status](https://www.r-pkg.org/badges/version/bifrost)](https://CRAN.R-project.org/package=bifrost)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/bifrost)](https://cran.r-project.org/package=bifrost)
+[![Paper: Nature Ecology & Evolution](https://img.shields.io/badge/paper-Nature%20Ecology%20%26%20Evolution-000000.svg)](http://rdcu.be/fuxB1)
 [![bioRxiv preprint](https://img.shields.io/endpoint?url=https%3A%2F%2Fjakeberv.github.io%2Fbiorxiv-badge%2Fbadges%2F10.64898__2026.04.12.718036.json)](https://doi.org/10.64898/2026.04.12.718036)
 [![License: GPL (>= 2)](https://img.shields.io/badge/license-GPL%20(%E2%89%A5%202)-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)


### PR DESCRIPTION
## Summary

- add a compact `paper | Nature Ecology & Evolution` badge to the README badge block
- link the badge to the author-provided SharedIt free-access URL

## Why

The published Nature Ecology & Evolution application paper is already cited on the site, but it is not surfaced alongside the project badges. This gives visitors a direct, prominent path to the published paper while preserving free access.

## Impact

The badge will appear in the README and the pkgdown homepage sidebar during the next site build. No package code or behavior changes.

## Validation

- confirmed the Shields badge endpoint renders the expected label
- confirmed `http://rdcu.be/fuxB1` resolves successfully to the Nature article sharing URL
- ran `git diff --check main...HEAD`
