### PR TITLE
Hide pkgdown theme switch

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -36,7 +36,6 @@ articles:
       - simulation-study-part-2
 template:
   bootstrap: 5
-  light-switch: true
   math-rendering: katex
   includes:
     in_header: |

--- a/tools/cran-downloads/dark-mode-design.md
+++ b/tools/cran-downloads/dark-mode-design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Render matching light and dark CRAN download charts and automatically show the appropriate version in both GitHub and pkgdown. Preserve the approved dark palette: `#0d1117` background, white labels and axes, coral cumulative series, and cyan rate series.
+Render matching light and dark CRAN download charts and automatically show the appropriate version in GitHub. Keep pkgdown in its default light mode without exposing a theme control, while preserving the existing switching mechanism for future use. Preserve the approved dark palette: `#0d1117` background, white labels and axes, coral cumulative series, and cyan rate series.
 
 ## Design
 
@@ -10,15 +10,15 @@ Render matching light and dark CRAN download charts and automatically show the a
 - Keep the current light outputs and add `cran-downloads-dark.svg` and `cran-downloads-dark.png` under `output/`.
 - Copy both PNG variants to `man/figures/`. Add `CRAN_DOWNLOADS_DARK_SVG`, `CRAN_DOWNLOADS_DARK_PNG`, and `CRAN_DOWNLOADS_DARK_README_PNG` for custom paths.
 - Use GitHub's supported `<picture>` and `prefers-color-scheme` pattern in the README, with the light image as fallback.
-- Enable pkgdown's Bootstrap 5 light switch. Extend `pkgdown/extra.js` to align the picture with pkgdown's current `data-bs-theme`, including manual overrides.
+- Keep pkgdown's Bootstrap light switch disabled so the site remains in its default light mode without a visible selector. Retain the existing `pkgdown/extra.js` synchronizer unchanged.
 - Track both variants in the weekly workflow and update the tracker documentation.
 
 ## Verification
 
 - Renderer tests verify both themes and their expected colors; existing invalid-window tests remain.
-- The pkgdown browser smoke test covers light, dark, and automatic selection.
+- The pkgdown browser smoke test verifies that no theme selector is rendered and the existing light, dark, and automatic source behavior remains available.
 - A render or conversion failure prevents the workflow from committing partial output.
 
 ## Acceptance
 
-GitHub and pkgdown select the appropriate chart; pkgdown theme changes update it without reloading; weekly automation updates both variants together.
+GitHub selects the chart from the system preference; pkgdown exposes no theme selector and uses its default light mode; weekly automation updates both variants together.

--- a/tools/cran-downloads/dark-mode-implementation-plan.md
+++ b/tools/cran-downloads/dark-mode-implementation-plan.md
@@ -58,7 +58,7 @@ const themes = [
 - Consumes `.cran-downloads-picture` with `source[data-theme="light|dark"]`.
 - Produces source `media="all"` for the active pkgdown theme and `media="not all"` for the inactive theme.
 
-- [ ] Add a Playwright test that sets `data-bs-theme` to dark and light and asserts the matching source becomes active without reloading.
+- [ ] Add a Playwright test that asserts pkgdown exposes no theme control while retaining light, dark, and automatic source behavior.
 - [ ] Build/serve pkgdown and run the focused smoke test; expect failure because the picture and synchronizer do not exist.
 - [ ] Replace the README image with GitHub's supported markup:
 
@@ -70,9 +70,9 @@ const themes = [
 </picture>
 ```
 
-- [ ] Set `template.light-switch: true` in `_pkgdown.yml`.
+- [ ] Leave pkgdown's `template.light-switch` disabled so the site uses its default light mode.
 - [ ] Add a DOM-ready synchronizer and `MutationObserver` in `pkgdown/extra.js` that updates the two source media attributes from the root `data-bs-theme` value.
-- [ ] Rebuild pkgdown and run the focused smoke test; expect it to pass for light, dark, and auto behavior.
+- [ ] Rebuild pkgdown and run the focused smoke test; expect no visible selector and preserved light, dark, and auto behavior.
 - [ ] Commit the display slice with `git commit -m "Switch CRAN chart with site theme"`.
 
 ### Task 3: Verify and Publish

--- a/tools/pkgdown-browser-smoke/pkgdown-smoke.spec.js
+++ b/tools/pkgdown-browser-smoke/pkgdown-smoke.spec.js
@@ -61,7 +61,7 @@ test("homepage provenance guide targets the tracked main documentation", async (
   );
 });
 
-test("CRAN downloads chart follows the pkgdown color mode", async ({ page }) => {
+test("CRAN downloads chart keeps automatic switching without exposing color-mode controls", async ({ page }) => {
   await stubExternalServices(page);
   await page.goto("/");
 
@@ -69,6 +69,7 @@ test("CRAN downloads chart follows the pkgdown color mode", async ({ page }) => 
   const darkSource = picture.locator('source[data-theme="dark"]');
   const lightSource = picture.locator('source[data-theme="light"]');
   await expect(picture).toHaveCount(1);
+  await expect(page.locator("#dropdown-lightswitch")).toHaveCount(0);
 
   await page.evaluate(() => document.documentElement.setAttribute("data-bs-theme", "dark"));
   await expect(darkSource).toHaveAttribute("media", "all");


### PR DESCRIPTION
## Summary

- keep pkgdown in its default light mode without a visible selector
- preserve the existing README and chart-switching implementation
- document and test the intended distinction

## Validation

- pkgdown configuration validation
- browser smoke tests: 7/7
- chart tests: 6/6
- `git diff --check`