### PR TITLE
Default pkgdown CRAN chart to light

### DIFF
--- a/pkgdown/extra.js
+++ b/pkgdown/extra.js
@@ -15,13 +15,15 @@ const ARTICLE_ARTIFACT_SLUGS = new Set([
 ]);
 
 (function syncCranDownloadsTheme() {
+  const defaultTheme = "light";
   const preferredMedia = {
     dark: "(prefers-color-scheme: dark)",
     light: "(prefers-color-scheme: light)"
   };
 
   const sync = () => {
-    const activeTheme = document.documentElement.getAttribute("data-bs-theme");
+    const activeTheme =
+      document.documentElement.getAttribute("data-bs-theme") || defaultTheme;
     document.querySelectorAll("picture.cran-downloads-picture").forEach(picture => {
       picture.querySelectorAll("source[data-theme]").forEach(source => {
         const sourceTheme = source.getAttribute("data-theme");

--- a/tools/cran-downloads/dark-mode-design.md
+++ b/tools/cran-downloads/dark-mode-design.md
@@ -10,13 +10,13 @@ Render matching light and dark CRAN download charts and automatically show the a
 - Keep the current light outputs and add `cran-downloads-dark.svg` and `cran-downloads-dark.png` under `output/`.
 - Copy both PNG variants to `man/figures/`. Add `CRAN_DOWNLOADS_DARK_SVG`, `CRAN_DOWNLOADS_DARK_PNG`, and `CRAN_DOWNLOADS_DARK_README_PNG` for custom paths.
 - Use GitHub's supported `<picture>` and `prefers-color-scheme` pattern in the README, with the light image as fallback.
-- Keep pkgdown's Bootstrap light switch disabled so the site remains in its default light mode without a visible selector. Retain the existing `pkgdown/extra.js` synchronizer unchanged.
+- Keep pkgdown's Bootstrap light switch disabled so the site remains in its default light mode without a visible selector. Default the existing `pkgdown/extra.js` synchronizer to light while preserving explicit light, dark, and auto handling.
 - Track both variants in the weekly workflow and update the tracker documentation.
 
 ## Verification
 
 - Renderer tests verify both themes and their expected colors; existing invalid-window tests remain.
-- The pkgdown browser smoke test verifies that no theme selector is rendered and the existing light, dark, and automatic source behavior remains available.
+- The pkgdown browser smoke test verifies that no theme selector is rendered, light is the default, and explicit light, dark, and automatic source behavior remains available.
 - A render or conversion failure prevents the workflow from committing partial output.
 
 ## Acceptance

--- a/tools/cran-downloads/dark-mode-implementation-plan.md
+++ b/tools/cran-downloads/dark-mode-implementation-plan.md
@@ -56,7 +56,7 @@ const themes = [
 
 **Interfaces:**
 - Consumes `.cran-downloads-picture` with `source[data-theme="light|dark"]`.
-- Produces source `media="all"` for the active pkgdown theme and `media="not all"` for the inactive theme.
+- With `data-bs-theme="light|dark"`, produces source `media="all"` for the active theme and `media="not all"` for the inactive theme; `auto` restores the `prefers-color-scheme` media queries, while an unset value defaults to light.
 
 - [ ] Add a Playwright test that asserts pkgdown exposes no theme control while retaining light, dark, and automatic source behavior.
 - [ ] Build/serve pkgdown and run the focused smoke test; expect failure because the picture and synchronizer do not exist.
@@ -71,7 +71,7 @@ const themes = [
 ```
 
 - [ ] Leave pkgdown's `template.light-switch` disabled so the site uses its default light mode.
-- [ ] Add a DOM-ready synchronizer and `MutationObserver` in `pkgdown/extra.js` that updates the two source media attributes from the root `data-bs-theme` value.
+- [ ] Retain the existing DOM-ready synchronizer and `MutationObserver` in `pkgdown/extra.js`, changing only the unset theme default to light while preserving explicit auto handling.
 - [ ] Rebuild pkgdown and run the focused smoke test; expect no visible selector and preserved light, dark, and auto behavior.
 - [ ] Commit the display slice with `git commit -m "Switch CRAN chart with site theme"`.
 

--- a/tools/pkgdown-browser-smoke/pkgdown-smoke.spec.js
+++ b/tools/pkgdown-browser-smoke/pkgdown-smoke.spec.js
@@ -61,7 +61,7 @@ test("homepage provenance guide targets the tracked main documentation", async (
   );
 });
 
-test("CRAN downloads chart keeps automatic switching without exposing color-mode controls", async ({ page }) => {
+test("CRAN downloads chart defaults to light without exposing color-mode controls", async ({ page }) => {
   await stubExternalServices(page);
   await page.goto("/");
 
@@ -70,6 +70,8 @@ test("CRAN downloads chart keeps automatic switching without exposing color-mode
   const lightSource = picture.locator('source[data-theme="light"]');
   await expect(picture).toHaveCount(1);
   await expect(page.locator("#dropdown-lightswitch")).toHaveCount(0);
+  await expect(lightSource).toHaveAttribute("media", "all");
+  await expect(darkSource).toHaveAttribute("media", "not all");
 
   await page.evaluate(() => document.documentElement.setAttribute("data-bs-theme", "dark"));
   await expect(darkSource).toHaveAttribute("media", "all");
@@ -79,9 +81,13 @@ test("CRAN downloads chart keeps automatic switching without exposing color-mode
   await expect(lightSource).toHaveAttribute("media", "all");
   await expect(darkSource).toHaveAttribute("media", "not all");
 
-  await page.evaluate(() => document.documentElement.removeAttribute("data-bs-theme"));
+  await page.evaluate(() => document.documentElement.setAttribute("data-bs-theme", "auto"));
   await expect(darkSource).toHaveAttribute("media", "(prefers-color-scheme: dark)");
   await expect(lightSource).toHaveAttribute("media", "(prefers-color-scheme: light)");
+
+  await page.evaluate(() => document.documentElement.removeAttribute("data-bs-theme"));
+  await expect(lightSource).toHaveAttribute("media", "all");
+  await expect(darkSource).toHaveAttribute("media", "not all");
 });
 
 test("vignette pages expose artifact actions and initialize Mermaid", async ({ page }) => {


### PR DESCRIPTION
## Summary

- default the pkgdown CRAN downloads chart to light when no theme is set
- preserve explicit `light`, `dark`, and `auto` handling without exposing a selector
- address the two post-merge Copilot documentation comments from #213

## Validation

- pkgdown browser smoke: 7/7 passed
- `node --check pkgdown/extra.js`
- `git diff --check`