### PR TITLE
Fix permanent SharedIt redirect for CRAN resubmission

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codecov test coverage](https://codecov.io/gh/jakeberv/bifrost/graph/badge.svg)](https://app.codecov.io/gh/jakeberv/bifrost)
 [![CRAN status](https://www.r-pkg.org/badges/version/bifrost)](https://CRAN.R-project.org/package=bifrost)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/bifrost)](https://cran.r-project.org/package=bifrost)
-[![Paper: Nature Ecology & Evolution](https://img.shields.io/badge/paper-Nature%20Ecology%20%26%20Evolution-000000.svg)](https://rdcu.be/fuxB1)
+[![Paper: Nature Ecology & Evolution](https://img.shields.io/badge/paper-Nature%20Ecology%20%26%20Evolution-000000.svg)](https://www.nature.com/articles/s41559-026-03110-5.epdf?sharing_token=PNALt0fkwK7zWng8AcHUw9RgN0jAjWel9jnR3ZoTv0MY7RbzUNNAnMQsco3ST9ehysSF4OiMNSc7ku-ywR1G5HC7BVOhY0inuNGDXiP16Z26oaZtwiblA-f61S2M-2llNRsRbegpuTeyhziEWzMipUgtyZKBEe3dsZlBVa67S4c%3D)
 [![bioRxiv preprint](https://img.shields.io/endpoint?url=https%3A%2F%2Fjakeberv.github.io%2Fbiorxiv-badge%2Fbadges%2F10.64898__2026.04.12.718036.json)](https://doi.org/10.64898/2026.04.12.718036)
 [![License: GPL (>= 2)](https://img.shields.io/badge/license-GPL%20(%E2%89%A5%202)-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 [![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,14 @@
-# Submission
+# Resubmission
 
-This is the `bifrost` 0.2.0 release, updating CRAN version 0.1.4.
+This is a resubmission of the `bifrost` 0.2.0 release, updating CRAN version
+0.1.4.
+
+## Changes in this resubmission
+
+The permanently redirecting `rdcu.be` SharedIt URL reported by the incoming
+pretests has been replaced in `README.md` by the publisher's canonical,
+tokenized SharedIt ePDF URL. This preserves free access to the article while
+avoiding the permanent redirect.
 
 ## Major changes
 
@@ -16,11 +24,6 @@ source package. `bifrost_example_file()` accesses the network only after an
 explicit user request, verifies artifact SHA-256 and byte size, and fails
 gracefully. Installation, attachment, examples, and checks remain network-free.
 
-## URL note
-
-The publisher's free-access SharedIt URL <https://rdcu.be/fuxB1> redirects over
-HTTPS to the corresponding article PDF and returns HTTP status 200.
-
 ## Test environments
 
 - macOS Sequoia 15.7.8, aarch64, R 4.4.2
@@ -29,7 +32,6 @@ HTTPS to the corresponding article PDF and returns HTTP status 200.
 
 `R CMD check --as-cran --run-donttest`:
 
-0 errors | 0 warnings | 2 notes
+0 errors | 0 warnings | 1 note
 
-The notes are the SharedIt redirect described above and the local environment's
-inability to verify the current time.
+The note is the local environment's inability to verify the current time.


### PR DESCRIPTION
## Summary

- replace the permanently redirecting `rdcu.be` badge target with Nature's canonical tokenized SharedIt ePDF URL
- preserve free access to the paper
- update `cran-comments.md` to explain the 0.2.0 resubmission and the addressed pretest finding

## Why

CRAN's Windows and Debian incoming pretests otherwise passed, but both returned one NOTE because the short SharedIt URL responded with HTTP 301. CRAN requested that the permanent redirect be replaced before resubmission.

## Impact

This is a documentation-only correction. It does not change package code, APIs, dependencies, examples, or tests.

## Validation

- complete CRAN-oriented `urlchecker` scan: all URLs correct, zero findings
- fresh `R CMD check --as-cran --run-donttest`: 0 errors, 0 warnings, 1 expected local clock-verification note
- `git diff --check`: passed
